### PR TITLE
UnitClasses.sqf Updates

### DIFF
--- a/Code/functions/Common/fn_initLocalPlayer.sqf
+++ b/Code/functions/Common/fn_initLocalPlayer.sqf
@@ -89,6 +89,8 @@ if (isMultiplayer) then {
 waituntil{sleep 0.1;!isNil("A3E_ParamsParsed")};
 AT_Revive_Camera = Param_ReviveView;
 
+setTerrainGrid Param_Grass;
+
 if (Param_Magrepack == 1) then {
 	[] execVM "Scripts\outlw_magRepack\MagRepack_init_sv.sqf";
 };

--- a/Mods/CUP RU/UnitClasses.sqf
+++ b/Mods/CUP RU/UnitClasses.sqf
@@ -22,11 +22,12 @@ A3E_VAR_Side_Ind_Str = format["%1",A3E_VAR_Side_Ind]; // CUP NAPA
 
 // Random array. Start position guard types around the prison.
 a3e_arr_Escape_StartPositionGuardTypes = [
-	"CUP_I_GUE_Soldier_AKS74"
+    "CUP_I_GUE_Soldier_AKS74"
 	,"CUP_I_GUE_Soldier_AKM"
 	,"CUP_I_GUE_Soldier_AKSU"
 	,"CUP_I_GUE_Soldier_GL"
-	,"CUP_I_GUE_Soldier_AR"];
+	,"CUP_I_GUE_Soldier_AR"
+	,"CUP_I_GUE_Soldier_AKS74"];
 
 // Prison backpack secondary weapon (and corresponding magazine type).
 a3e_arr_PrisonBackpackWeapons = [];
@@ -263,15 +264,15 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_O_Vodnik_PK_RU"
-	,"CUP_O_Vodnik_hmg_RU"
-	,"CUP_I_BRDM2_NAPA"];
+	"CUP_O_GAZ_Vodnik_BPPU_RU"
+	,"CUP_O_BRDM2_RUS"
+	,"CUP_O_BRDM2_ATGM_RUS"
+	,"CUP_O_BTR60_RU"
+	,"CUP_0_BTR90_RU"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_O_2S6M_RU"
-	,"CUP_O_BMP2_RU"
-	,"CUP_O_BMP3_RU"
-	,"CUP_O_T72_RU"];
+	,"CUP_O_T90_RU"];
 
 // A communication center contains two static weapons (in two corners of the communication center).
 // Random array. Possible static weapon types for communication centers.
@@ -374,7 +375,6 @@ a3e_arr_O_attack_heli = [
 	,"CUP_O_Ka52_Blk_RU"
 	,"CUP_O_Mi24_P_RU"
 	,"CUP_O_Mi24_V_RU"
-	,"CUP_O_Ka60_Grey_RU"
 	,"CUP_O_Ka52_RU"
 	,"CUP_O_Ka52_Blk_RU"
 	,"CUP_O_Ka52_GreyCamo_RU"
@@ -384,16 +384,15 @@ a3e_arr_O_transport_heli = [
 	,"CUP_O_MI6T_RU"
 	,"CUP_O_Mi8_RU"
 	,"CUP_O_Mi8_medevac_RU"
-	,"CUP_O_Mi8_VIV_RU"
 	,"CUP_O_Mi8_RU"];
 a3e_arr_O_pilots = [
 	"CUP_O_RU_Pilot_VDV"];
 a3e_arr_I_transport_heli = [
-	"CUP_I_SA330_Puma_HC1_RACS"
-	,"CUP_I_SA330_Puma_HC2_RACS"
-	,"CUP_I_UH60L_FFV_RACS"
-	,"CUP_I_UH60L_Unarmed_FFV_Racs"
-	,"CUP_I_UH60L_Unarmed_FFV_MEV_Racs"];
+	"CUP_O_MI6A_RU"
+	,"CUP_O_MI6T_RU"
+	,"CUP_O_Mi8_RU"
+	,"CUP_O_Mi8_medevac_RU"
+	,"CUP_O_Mi8_RU"];
 a3e_arr_I_pilots = [
 	"CUP_I_GUE_Pilot"];
 
@@ -635,18 +634,15 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"CUP_B_MH6J_USA"
+	"CUP_B_MH60L_DAP_2x_USN"
+	,"CUP_B_MH60L_DAP_4x_USN"
 	,"CUP_B_MH60S_FFV_USMC"
-	,"CUP_B_CH47F_USA"
-	,"CUP_B_UH60M_FFV_US"
-	,"CUP_B_UH60M_Unarmed_FFV_US"
-	,"CUP_B_UH60M_Unarmed_FFV_MEV_US"
-	,"CUP_B_CH53E_USMC"
-	,"CUP_B_UH1Y_MEV_USMC",
-	"CUP_B_UH1Y_UNA_USMC"];
+	,"CUP_B_UH60S_USN"
+	,"CUP_B_UH1Y_Gunship_Dynamic_USMC"
+	,"CUP_B_MV22_USMC_RAMPGUN"
+	,"CUP_B_MV22_USMC_RAMPGUN"];
 a3e_arr_extraction_chopper_escort = [
-	"CUP_B_AH1Z_USMC"
-	,"CUP_B_AH64D_MR_USA"];
+	"CUP_B_AH1Z_USMC"];
 
 //////////////////////////////////////////////////////////////////
 // EscapeSurprises.sqf and CreateSearchDrone.sqf

--- a/Mods/CUP SLA/UnitClasses.sqf
+++ b/Mods/CUP SLA/UnitClasses.sqf
@@ -301,20 +301,18 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_I_M113_RACS"
-	,"CUP_O_BRDM2_SLA"
-	,"CUP_O_BRDM2_ATGM_SLA"];
+	"CUP_O_BRDM2_SLA"
+	,"CUP_O_BRDM2_ATGM_SLA"
+	,"CUP_O_BTR60_SLA"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_O_ZSU23_SLA"
-	,"CUP_O_BMP2_SLA"
 	,"CUP_O_T72_SLA"];
 
 // A communication center contains two static weapons (in two corners of the communication center).
 // Random array. Possible static weapon types for communication centers.
 a3e_arr_ComCenStaticWeapons = [
-	"CUP_I_KORD_high_AAF"
-	,"CUP_I_DSHKM_AAF"];
+	"CUP_O_DSHKM_SLA"];
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
 	"I_G_Offroad_01_repair_F"
@@ -404,18 +402,22 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
 	"CUP_O_Ka50_AA_SLA"
-	,"CUP_O_Ka50_SLA"];
+	,"CUP_O_Ka50_SLA"
+	,"CUP_O_Mi24_D_Dynamic_SLA"];
 a3e_arr_O_transport_heli = [
 	"CUP_O_Mi8_SLA_1"
-	,"CUP_O_Mi8_SLA_2"];
+	,"CUP_O_Mi8_SLA_2"
+	,"CUP_O_MI6T_SLA"];
 a3e_arr_O_pilots = [
 	"CUP_O_SLA_Pilot"];
 a3e_arr_I_transport_heli = [
-	"CUP_I_SA330_Puma_HC1_RACS"
+    "CUP_I_CH47F_RACS"
+	,"CUP_I_SA330_Puma_HC1_RACS"
 	,"CUP_I_SA330_Puma_HC2_RACS"
+	,"CUP_I_UH60L_RACS"
 	,"CUP_I_UH60L_FFV_RACS"
-	,"CUP_I_UH60L_Unarmed_FFV_Racs"
-	,"CUP_I_UH60L_Unarmed_FFV_MEV_Racs"];
+	,"CUP_I_UH60L_Unarmed_Racs"
+	,"CUP_I_UH60L_Unarmed_FFV_Racs"];
 a3e_arr_I_pilots = [
 	"CUP_I_RACS_Pilot"];
 
@@ -657,28 +659,22 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"CUP_B_MH6J_USA"
+	"CUP_B_MH60L_DAP_2x_USN"
+	,"CUP_B_MH60L_DAP_4x_USN"
 	,"CUP_B_MH60S_FFV_USMC"
-	,"CUP_B_CH47F_USA"
-	,"CUP_B_UH60M_FFV_US"
-	,"CUP_B_UH60M_Unarmed_FFV_US"
-	,"CUP_B_UH60M_Unarmed_FFV_MEV_US"
-	,"CUP_B_CH53E_USMC"
-	,"CUP_B_UH1Y_MEV_USMC",
-	"CUP_B_UH1Y_UNA_USMC"];
+	,"CUP_B_UH60S_USN"
+	,"CUP_B_UH1Y_Gunship_Dynamic_USMC"
+	,"CUP_B_MV22_USMC_RAMPGUN"
+	,"CUP_B_MV22_USMC_RAMPGUN"];
 a3e_arr_extraction_chopper_escort = [
-	"CUP_B_AH1Z_USMC"
-	,"CUP_B_AH64D_MR_USA"];
+	"CUP_B_AH1Z_USMC"];
 
 //////////////////////////////////////////////////////////////////
 // EscapeSurprises.sqf and CreateSearchDrone.sqf
 // Classnames of drones
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchdrone = [
-	"CUP_USMC_MQ9"
-	,"CUP_USMC_MQ9"
-	,"CUP_USMC_MQ9"
-	,"CUP_I_C130J_RACS"];
+	"CUP_O_Pchela1T_RU"];
 
 //////////////////////////////////////////////////////////////////
 // CreateSearchChopper.sqf
@@ -686,20 +682,13 @@ a3e_arr_searchdrone = [
 // Two arrays for "Easy" and "Hard" parameter, both used on stadard setting
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchChopperEasy = [
-	"CUP_I_SA330_Puma_HC1_RACS"
-	,"CUP_I_SA330_Puma_HC2_RACS"
-	,"CUP_I_MH6J_RACS"
+	"CUP_I_MH6J_RACS"
 	,"CUP_I_UH60L_Unarmed_FFV_Racs"];
 a3e_arr_searchChopperHard = [
 	"CUP_I_UH60L_FFV_RACS"
 	,"CUP_I_AH6J_Escort19_RACS"
 	,"CUP_I_AH6J_Escort_RACS"
-	,"CUP_I_AH6J_MP_RACS"
-	,"CUP_I_CH47F_RACS"];
-a3e_arr_searchChopper_pilot = [
-	"CUP_I_RACS_Pilot"];
-a3e_arr_searchChopper_crew = [
-	"CUP_I_RACS_Pilot"];
+	,"CUP_I_AH6J_MP_RACS"];
 
 if(Param_SearchChopper==0) then {
 	a3e_arr_searchChopper = a3e_arr_searchChopperEasy + a3e_arr_searchChopperHard;

--- a/Mods/CUP Taki/UnitClasses.sqf
+++ b/Mods/CUP Taki/UnitClasses.sqf
@@ -382,7 +382,8 @@ a3e_arr_ComCenDefence_lightArmorClasses = [
 	"CUP_O_M113_TKA"
 	,"CUP_O_BRDM2_TKA"
 	,"CUP_O_BRDM2_ATGM_TKA"
-	,"CUP_O_BTR60_TK"];
+	,"CUP_O_BTR60_TK"
+	,"CUP_O_BMP2_ZU_TKA"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_O_ZSU23_TK"
@@ -392,8 +393,7 @@ a3e_arr_ComCenDefence_heavyArmorClasses = [
 // A communication center contains two static weapons (in two corners of the communication center).
 // Random array. Possible static weapon types for communication centers.
 a3e_arr_ComCenStaticWeapons = [
-	"CUP_I_KORD_high_AAF"
-	,"CUP_I_DSHKM_AAF"];
+	"CUP_O_KORD_high_TK"];
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
 	"I_G_Offroad_01_repair_F"
@@ -492,8 +492,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_O_Mi24_D_TK"
-	,"CUP_O_Mi17_TK"];
+	"CUP_O_Mi24_D_TK"];
 a3e_arr_O_transport_heli = [
 	"CUP_O_Mi17_TK"
 	,"CUP_O_UH1H_TKA"
@@ -744,16 +743,10 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"CUP_B_MH6J_USA"
-	,"CUP_B_MH60S_FFV_USMC"
-	,"CUP_B_CH47F_USA"
-	,"CUP_B_CH47F_VIV_USA"
-	,"CUP_B_UH60M_FFV_US"
-	,"CUP_B_UH60M_Unarmed_FFV_US"
-	,"CUP_B_UH60M_Unarmed_FFV_MEV_US"
-	,"CUP_B_CH53E_USMC"
-	,"CUP_B_UH1Y_MEV_USMC",
-	"CUP_B_UH1Y_UNA_USMC"];
+	 "CUP_B_UH1D_GER_KSK_Des"
+	,"CUP_B_UH1D_armed_GER_KSK_Des"
+	,"CUP_B_UH1D_gunship_GER_KSK_Des"
+	,"CUP_B_UH1D_slick_GER_KSK_Des"];
 a3e_arr_extraction_chopper_escort = [
 	"CUP_B_AH1Z_USMC"
 	,"CUP_B_AH64D_MR_USA"];
@@ -763,10 +756,7 @@ a3e_arr_extraction_chopper_escort = [
 // Classnames of drones
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchdrone = [
-	"O_UAV_01_F"
-	,"O_UAV_02_CAS_F"
-	,"O_UAV_02_F"
-	,"O_UAV_02_F"];
+	"CUP_O_Pchela1T_RU"];
 
 //////////////////////////////////////////////////////////////////
 // CreateSearchChopper.sqf

--- a/Mods/CUP-BAF d/UnitClasses.sqf
+++ b/Mods/CUP-BAF d/UnitClasses.sqf
@@ -397,15 +397,8 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_B_LR_MG_GB_W"
-	,"CUP_B_Ridgback_LMG_GB_D"
-	,"CUP_B_Ridgback_HMG_GB_D"
+	 "CUP_B_Ridgback_HMG_GB_D"
 	,"CUP_B_Ridgback_GMG_GB_D"
-	,"CUP_B_Mastiff_LMG_GB_D"
-	,"CUP_B_Jackal2_L2A1_GB_D"
-	,"CUP_B_Jackal2_GMG_GB_D"
-	,"CUP_B_BAF_Coyote_L2A1_D"
-	,"CUP_B_BAF_Coyote_GMG_D"
 	,"CUP_B_FV432_Bulldog_GB_D_RWS"
 	,"CUP_B_FV432_Bulldog_GB_D"];
 // Random array. Heavy armored vehicles guarding the communication centers.
@@ -419,7 +412,7 @@ a3e_arr_ComCenDefence_heavyArmorClasses = [
 // A communication center contains two static weapons (in two corners of the communication center).
 // Random array. Possible static weapon types for communication centers.
 a3e_arr_ComCenStaticWeapons = [
-	"CUP_B_L111A1_BAF_MPT"];
+	"CUP_B_L111A1_BAF_DDPM"];
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
 	"I_G_Offroad_01_repair_F"
@@ -510,13 +503,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_B_AH1_DL_BAF"
-	,"CUP_B_AW159_RN_Blackcat"
-	,"CUP_B_AW159_GB"
-	,"CUP_B_AW159_RN_Grey"
-	,"CUP_B_Mi171Sh_ACR"
-	,"CUP_B_Mi35_Dynamic_CZ_Des"
-	,"CUP_B_Mi35_Dynamic_CZ_Tiger"];
+	"CUP_B_AH1_DL_BAF"];
 a3e_arr_O_transport_heli = [
 	"CUP_B_AW159_Unarmed_RN_Blackcat"
 	,"CUP_B_AW159_Unarmed_GB"
@@ -793,9 +780,7 @@ a3e_arr_Bipods = [
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
 	"CUP_O_Mi8_RU"
-	,"CUP_O_Mi8_medevac_RU"
-	,"CUP_O_Ka60_Grey_RU"
-	,"CUP_O_MI6T_RU"];
+	,"CUP_O_Mi24_V_RU"];
 a3e_arr_extraction_chopper_escort = [
 	"CUP_O_Ka52_RU"
 	,"CUP_O_Ka52_Blk_RU"
@@ -811,8 +796,7 @@ a3e_arr_extraction_chopper_escort = [
 // Classnames of drones
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchdrone = [
-	"CUP_USMC_MQ9"
-	,"CUP_B_AH6X_USA"];
+	"CUP_USMC_MQ9"];
 
 //////////////////////////////////////////////////////////////////
 // CreateSearchChopper.sqf
@@ -820,13 +804,17 @@ a3e_arr_searchdrone = [
 // Two arrays for "Easy" and "Hard" parameter, both used on stadard setting
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchChopperEasy = [
-	"CUP_B_Mi171Sh_Unarmed_ACR"];
+	"CUP_B_AW159_Unarmed_RN_Blackcat"
+	,"CUP_B_AW159_Unarmed_RN_Grey"
+	,"CUP_B_AW159_Unarmed_GB"];
 a3e_arr_searchChopperHard = [
-	"CUP_B_Mi171Sh_ACR"];
+	"CUP_B_AW159_GB"
+   ,"CUP_B_AW159_RN_Blackcat"
+   ,"CUP_B_AW159_RN_Grey"];
 a3e_arr_searchChopper_pilot = [
-	"CUP_B_CZ_Pilot_DES"];
+	"CUP_B_BAF_Soldier_Helipilot_MTP"];
 a3e_arr_searchChopper_crew = [
-	"CUP_B_CZ_Pilot_DES"];
+	"CUP_B_BAF_Soldier_Helipilot_MTP"];
 
 if(Param_SearchChopper==0) then {
 	a3e_arr_searchChopper = a3e_arr_searchChopperEasy + a3e_arr_searchChopperHard;

--- a/Mods/CUP-BAF w/UnitClasses.sqf
+++ b/Mods/CUP-BAF w/UnitClasses.sqf
@@ -434,18 +434,10 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_B_LR_MG_GB_W"
-	,"CUP_B_Ridgback_LMG_GB_W"
-	,"CUP_B_Ridgback_HMG_GB_W"
+	"CUP_B_Ridgback_HMG_GB_W"
 	,"CUP_B_Ridgback_GMG_GB_W"
-	,"CUP_B_Mastiff_LMG_GB_W"
-	,"CUP_B_Jackal2_L2A1_GB_W"
-	,"CUP_B_Jackal2_GMG_GB_W"
-	,"CUP_B_BAF_Coyote_L2A1_W"
-	,"CUP_B_BAF_Coyote_GMG_W"
-	,"CUP_B_FV432_Bulldog_GB_W_RWS"
 	,"CUP_B_FV432_Bulldog_GB_W"
-	,"CUP_I_SUV_Armored_ION"];
+	,"CUP_B_FV432_Bulldog_GB_W_RWS"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_B_FV510_GB_W_SLAT"
@@ -543,13 +535,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_B_AH1_DL_BAF"
-	,"CUP_B_AW159_RN_Blackcat"
-	,"CUP_B_AW159_GB"
-	,"CUP_B_AW159_RN_Grey"
-	,"CUP_I_Mi24_D_ION"
-	,"CUP_I_Mi24_Mk3_ION"
-	,"CUP_I_Mi24_Mk4_ION"];
+	"CUP_B_AH1_DL_BAF"];
 a3e_arr_O_transport_heli = [
 	"CUP_B_AW159_Unarmed_RN_Blackcat"
 	,"CUP_B_AW159_Unarmed_GB"
@@ -822,9 +808,7 @@ a3e_arr_Bipods = [
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
 	"CUP_O_Mi8_RU"
-	,"CUP_O_Mi8_medevac_RU"
-	,"CUP_O_Ka60_Grey_RU"
-	,"CUP_O_MI6T_RU"];
+	,"CUP_O_Mi24_V_RU"];
 a3e_arr_extraction_chopper_escort = [
 	"CUP_O_Ka52_RU"
 	,"CUP_O_Ka52_Blk_RU"
@@ -840,9 +824,7 @@ a3e_arr_extraction_chopper_escort = [
 // Classnames of drones
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchdrone = [
-	"CUP_USMC_MQ9"
-	,"CUP_B_AH6X_USA"
-	,"CUP_I_Plane_ION"];
+	"CUP_USMC_MQ9"];
 
 //////////////////////////////////////////////////////////////////
 // CreateSearchChopper.sqf

--- a/Mods/CUP-CDF winter/UnitClasses.sqf
+++ b/Mods/CUP-CDF winter/UnitClasses.sqf
@@ -410,12 +410,9 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_B_MTLB_pk_Winter_CDF"
-	,"CUP_B_BTR60_CDF"
-	,"CUP_B_BRDM2_HQ_CDF"
+	 "CUP_B_BTR60_CDF"
 	,"CUP_B_BRDM2_CDF"
-	,"CUP_B_BMP_HQ_CDF"
-	,"CUP_B_BMP2_CDF"];
+	,"CUP_B_BRDM2_ATGM_CDF"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_B_ZSU23_CDF"
@@ -519,11 +516,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_B_Mi24_D_Dynamic_CDF"
-	,"CUP_B_Mi24_D_MEV_Dynamic_CDF"
-	,"CUP_I_Mi24_D_ION"
-	,"CUP_I_Mi24_Mk3_ION"
-	,"CUP_I_Mi24_Mk4_ION"];
+	"CUP_B_Mi24_D_Dynamic_CDF"];
 a3e_arr_O_transport_heli = [
 	"CUP_B_Mi17_CDF"
 	,"CUP_B_Mi17_medevac_CDF"
@@ -790,9 +783,7 @@ a3e_arr_Bipods = [
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
 	"CUP_O_Mi8_RU"
-	,"CUP_O_Mi8_medevac_RU"
-	,"CUP_O_Ka60_Grey_RU"
-	,"CUP_O_MI6T_RU"];
+	,"CUP_O_Mi24_V_RU"];
 a3e_arr_extraction_chopper_escort = [
 	"CUP_O_Ka52_RU"
 	,"CUP_O_Ka52_Blk_RU"
@@ -822,9 +813,9 @@ a3e_arr_searchChopperHard = [
 	"CUP_I_Ka60_Blk_ION"
 	,"CUP_I_Ka60_GL_Blk_ION"];
 a3e_arr_searchChopper_pilot = [
-	"CUP_I_PMC_Pilot"];
+	"CUP_I_PMC_Winter_Pilot"];
 a3e_arr_searchChopper_crew = [
-	"CUP_I_PMC_Pilot"];
+	"CUP_I_PMC_Winter_Pilot"];
 
 if(Param_SearchChopper==0) then {
 	a3e_arr_searchChopper = a3e_arr_searchChopperEasy + a3e_arr_searchChopperHard;

--- a/Mods/CUP-US Army d/UnitClasses.sqf
+++ b/Mods/CUP-US Army d/UnitClasses.sqf
@@ -426,30 +426,19 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_B_HMMWV_M2_USA"
-	,"CUP_B_HMMWV_MK19_USA"
-	,"CUP_B_HMMWV_TOW_USA"
-	,"CUP_B_HMMWV_M2_GPK_USA"
-	,"CUP_B_HMMWV_Crows_M2_USA"
-	,"CUP_B_HMMWV_Crows_MK19_USA"
-	,"CUP_B_HMMWV_SOV_M2_USA"
-	,"CUP_B_M113_desert_USA"
-	,"CUP_B_M1126_ICV_M2_Desert"
+	"CUP_B_M1126_ICV_M2_Desert"
 	,"CUP_B_M1126_ICV_MK19_Desert"
-	,"CUP_B_M1128_MGS_Desert"
 	,"CUP_B_M1135_ATGMV_Desert"
-	,"CUP_I_SUV_Armored_ION"
-	,"CUP_I_FENNEK_GMG_ION"
-	,"CUP_I_FENNEK_HMG_ION"
-	,"CUP_I_MATV_GMG_ION"
-	,"CUP_I_MATV_HMG_ION"];
+	,"CUP_B_M113_desert_USA"
+	,"CUP_B_RG31_M2_GC_USA"
+	,"CUP_B_RG31_M2_GC_USA"
+	,"CUP_B_RG31_Mk19_USA"
+	,"CUP_B_RG31_Mk19_USA"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
-	"CUP_B_M2Bradley_USA_D"
-	,"CUP_B_M2A3Bradley_USA_D"
-	,"CUP_B_M7Bradley_USA_D"
-	,"CUP_B_M1A1_Woodland_USMC"
-	,"CUP_B_M1A2_TUSK_MG_USMC"];
+	"CUP_B_M2A3Bradley_USA_D"
+	,"CUP_B_M1A1_DES_US_Army"
+	,"CUP_B_M1A2_TUSK_MG_DES_US_Army"];
 
 // A communication center contains two static weapons (in two corners of the communication center).
 // Random array. Possible static weapon types for communication centers.
@@ -540,13 +529,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_B_AH64D_DL_USA"
-	,"CUP_B_AH6J_USA"
-	,"CUP_B_AH6M_USA"
-	,"CUP_B_MH60L_DAP_4x_Multi_US"
-	,"CUP_I_Mi24_D_ION"
-	,"CUP_I_Mi24_Mk3_ION"
-	,"CUP_I_Mi24_Mk4_ION"];
+	"CUP_B_AH64D_DL_USA"];
 a3e_arr_O_transport_heli = [
 	"CUP_B_MH6J_USA"
 	,"CUP_B_MH6M_USA"
@@ -814,9 +797,7 @@ a3e_arr_Bipods = [
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
 	"CUP_O_Mi8_RU"
-	,"CUP_O_Mi8_medevac_RU"
-	,"CUP_O_Ka60_Grey_RU"
-	,"CUP_O_MI6T_RU"];
+	,"CUP_O_Mi24_V_RU"];
 a3e_arr_extraction_chopper_escort = [
 	"CUP_O_Ka52_RU"
 	,"CUP_O_Ka52_Blk_RU"
@@ -833,8 +814,7 @@ a3e_arr_extraction_chopper_escort = [
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchdrone = [
 	"CUP_USMC_MQ9"
-	,"CUP_B_AH6X_USA"
-	,"CUP_I_Plane_ION"];
+	,"CUP_B_AH6X_USA"];
 
 //////////////////////////////////////////////////////////////////
 // CreateSearchChopper.sqf

--- a/Mods/CUP-US USMC/UnitClasses.sqf
+++ b/Mods/CUP-US USMC/UnitClasses.sqf
@@ -340,16 +340,12 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 // Random array. Light armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_lightArmorClasses = [
-	"CUP_B_HMMWV_M2_USMC"
-	,"CUP_B_HMMWV_MK19_USMC"
-	,"CUP_B_HMMWV_TOW_USMC"
-	,"CUP_B_HMMWV_M1114_USMC"
-	,"CUP_B_HMMWV_Avenger_USMC"
-	,"CUP_B_RG31_M2_OD_USMC"
+	"CUP_B_RG31_M2_OD_GC_USMC"
+	,"CUP_B_RG31_M2_OD_GC_USMC"
+	,"CUP_B_RG31_Mk19_OD_USMC"
 	,"CUP_B_RG31_Mk19_OD_USMC"
 	,"CUP_B_LAV25_USMC"
-	,"CUP_B_LAV25M240_USMC"
-	,"CUP_B_AAV_USMC"];
+	,"CUP_B_LAV25M240_USMC"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_B_M1A1_Woodland_USMC"
@@ -440,9 +436,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_B_AH1Z_Dynamic_USMC"
-	,"CUP_B_MH60L_DAP_4x_Multi_USN"
-	,"CUP_B_UH1Y_Gunship_Dynamic_USMC"];
+	"CUP_B_AH1Z_Dynamic_USMC"];
 a3e_arr_O_transport_heli = [
 	"CUP_B_UH1Y_MEV_USMC"
 	,"CUP_B_UH1Y_UNA_USMC"
@@ -455,7 +449,7 @@ a3e_arr_O_transport_heli = [
 a3e_arr_O_pilots = [
 	"CUP_B_USMC_Pilot"];
 a3e_arr_I_transport_heli = [
-	"CUP_B_UH60M_Unarmed_FFV_US"];
+	"CUP_I_UH1H_TK_GUE"];
 a3e_arr_I_pilots = [
 	"CUP_I_GUE_Pilot"];
 
@@ -709,9 +703,8 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"CUP_O_Mi8_SLA_1"
-	,"CUP_O_Mi8_SLA_2"
-	,"CUP_O_UH1H_SLA"];
+	"CUP_O_Mi8_SLA_2"
+	,"CUP_O_Mi24_D_Dynamic_SLA"];
 a3e_arr_extraction_chopper_escort = [
 	"CUP_O_Ka50_AA_SLA"
 	,"CUP_O_Ka50_SLA"
@@ -730,20 +723,17 @@ a3e_arr_searchdrone = [
 // Two arrays for "Easy" and "Hard" parameter, both used on stadard setting
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchChopperEasy = [
-	"CUP_B_UH1Y_UNA_USMC"
-	,"CUP_B_UH1Y_MEV_USMC"
-	,"CUP_B_CH53E_USMC"];
+	"CUP_B_UH1Y_UNA_USMC"];
 a3e_arr_searchChopperHard = [
-	"CUP_B_MH60S_FFV_USMC"
-	,"CUP_B_UH1Y_GUNSHIP_USMC"
-	,"CUP_B_MH60L_DAP_2x_Multi_USN"
-	,"CUP_B_MH60L_DAP_2x_Escort_USN"
-	,"CUP_B_MH60L_DAP_4x_Multi_USN"
-	,"CUP_B_MH60L_DAP_4x_Escort_USN"];
+     "CUP_B_MH60L_DAP_2x_USN"
+	,"CUP_B_MH60L_DAP_4x_USN"
+    ,"CUP_B_MH60S_USMC"
+	,"CUP_B_UH60S_USN"
+	,"CUP_B_UH1Y_Gunship_Dynamic_USMC"];
 a3e_arr_searchChopper_pilot = [
-	"CUP_I_GUE_Pilot"];
+	"CUP_B_USMC_Pilot"];
 a3e_arr_searchChopper_crew = [
-	"CUP_I_GUE_Pilot"];
+	"CUP_B_USMC_Pilot"];
 
 if(Param_SearchChopper==0) then {
 	a3e_arr_searchChopper = a3e_arr_searchChopperEasy + a3e_arr_searchChopperHard;

--- a/Mods/Vanilla Apex US/UnitClasses.sqf
+++ b/Mods/Vanilla Apex US/UnitClasses.sqf
@@ -460,10 +460,11 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"B_Heli_Light_01_dynamicLoadout_F"
-	,"B_Heli_Attack_01_dynamicLoadout_F"];
+	"B_Heli_Attack_01_dynamicLoadout_F"];
 a3e_arr_O_transport_heli = [
-	"B_Heli_Transport_01_F"];
+	"B_Heli_Transport_01_F"
+	,"B_Heli_Transport_01_F"
+	,"B_Heli_Light_01_F"];
 	if(Param_UseDLCHelis==1) then {
 	a3e_arr_O_transport_heli pushback "B_Heli_Transport_03_F";
 	a3e_arr_O_transport_heli pushback "B_Heli_Transport_03_unarmed_F";

--- a/Mods/Vanilla Apex/UnitClasses.sqf
+++ b/Mods/Vanilla Apex/UnitClasses.sqf
@@ -370,12 +370,12 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 a3e_arr_ComCenDefence_lightArmorClasses = [
 	"O_T_MRAP_02_gmg_ghex_F"
 	,"O_T_MRAP_02_hmg_ghex_F"
-	,"O_T_APC_Wheeled_02_rcws_ghex_F"
-	,"O_T_APC_Tracked_02_AA_ghex_F"];
+	,"O_T_APC_Wheeled_02_rcws_v2_ghex_F"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"O_T_MBT_02_cannon_ghex_F"
-	,"O_T_APC_Tracked_02_cannon_ghex_F"];
+	,"O_T_APC_Tracked_02_cannon_ghex_F"
+	,"O_T_APC_Tracked_02_AA_ghex_F"];
 	if(Param_UseDLCTanks==1) then {
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "O_T_MBT_04_cannon_F";
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "O_T_MBT_04_command_F";
@@ -469,7 +469,6 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
 	"O_Heli_Attack_02_black_F"
-	,"O_Heli_Light_02_F"
 	,"O_T_VTOL_02_infantry_F"];
 a3e_arr_O_transport_heli = [
 	"O_Heli_Light_02_unarmed_F"];
@@ -710,7 +709,10 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"B_Heli_Transport_03_F"];
+	"B_Heli_Transport_01_F"];
+	 if(Param_UseDLCHelis==1) then {
+	a3e_arr_O_transport_heli pushback "B_Heli_Transport_03_F";
+	};
 a3e_arr_extraction_chopper_escort = [
 	"B_Heli_Attack_01_F"];
 

--- a/Mods/Vanilla US/UnitClasses.sqf
+++ b/Mods/Vanilla US/UnitClasses.sqf
@@ -822,7 +822,6 @@ a3e_arr_extraction_chopper = [
     ,"O_Heli_Attack_02_dynamicLoadout_F"];
 	if(Param_UseDLCHelis==1) then {
 	a3e_arr_extraction_chopper pushback "O_Heli_Transport_04_bench_F";
-	a3e_arr_extraction_chopper pushback "O_Heli_Transport_04_covered_F";
 	};
 a3e_arr_extraction_chopper_escort = [
 	"O_Heli_Attack_02_dynamicLoadout_F"];

--- a/Mods/Vanilla US/UnitClasses.sqf
+++ b/Mods/Vanilla US/UnitClasses.sqf
@@ -474,16 +474,12 @@ a3e_arr_ComCenDefence_lightArmorClasses = [
 	"B_MRAP_01_gmg_F"
 	,"B_MRAP_01_hmg_F"
 	,"B_APC_Wheeled_01_cannon_F"
-	,"B_APC_Tracked_01_AA_F"];
-	if(Param_UseDLCTanks==1) then {
-		a3e_arr_ComCenDefence_LightArmorClasses pushback "B_AFV_Wheeled_01_cannon_F";
-	};
+	,"B_MRAP_01_gmg_F"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"B_MBT_01_cannon_F"
 	,"B_MBT_01_TUSK_F"
-	,"O_MBT_04_cannon_F"
-	,"O_MBT_04_command_F"];
+	,"B_APC_Tracked_01_AA_F"];
 	if(Param_UseDLCTanks==1) then {
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "B_AFV_Wheeled_01_up_cannon_F";
 	};
@@ -579,8 +575,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 	};
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"B_Heli_Attack_01_dynamicLoadout_F"
-	,"B_Heli_Light_01_dynamicLoadout_F"];
+	"B_Heli_Attack_01_dynamicLoadout_F"];
 a3e_arr_O_transport_heli = [
 	"B_Heli_Transport_01_F"
 	,"B_Heli_Transport_01_F"
@@ -823,8 +818,8 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"O_Heli_Light_02_dynamicLoadout_F"
-	,"O_Heli_Light_02_unarmed_F"];
+    "O_Heli_Attack_02_dynamicLoadout_F"
+    ,"O_Heli_Attack_02_dynamicLoadout_F"];
 	if(Param_UseDLCHelis==1) then {
 	a3e_arr_extraction_chopper pushback "O_Heli_Transport_04_bench_F";
 	a3e_arr_extraction_chopper pushback "O_Heli_Transport_04_covered_F";
@@ -856,13 +851,9 @@ a3e_arr_searchdrone = [
 // Two arrays for "Easy" and "Hard" parameter, both used on stadard setting
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchChopperEasy = [
-	"I_Heli_light_03_unarmed_F"
-	,"I_Heli_Transport_02_F"
-	,"B_Heli_Light_01_F"];
+	"I_Heli_light_03_unarmed_F"];
 a3e_arr_searchChopperHard = [
-	"I_Heli_light_03_F"
-	,"B_Heli_Transport_01_F"
-	,"B_Heli_Light_01_dynamicLoadout_F"];
+	"I_Heli_light_03_F"];
 a3e_arr_searchChopper_pilot = [
 	"I_helipilot_F"];
 a3e_arr_searchChopper_crew = [

--- a/Mods/Vanilla/UnitClasses.sqf
+++ b/Mods/Vanilla/UnitClasses.sqf
@@ -473,12 +473,12 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 a3e_arr_ComCenDefence_lightArmorClasses = [
 	"O_MRAP_02_gmg_F"
 	,"O_MRAP_02_hmg_F"
-	,"O_APC_Wheeled_02_rcws_F"
-	,"O_APC_Tracked_02_AA_F"];
+	,"O_APC_Wheeled_02_rcws_F"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"O_MBT_02_cannon_F"
-	,"O_APC_Tracked_02_cannon_F"];
+	,"O_APC_Tracked_02_cannon_F"
+	,"O_APC_Tracked_02_AA_F"];
 	if(Param_UseDLCTanks==1) then {
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "O_MBT_04_cannon_F";
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "O_MBT_04_command_F";
@@ -581,8 +581,7 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
 	"O_Heli_Attack_02_F"
-	,"O_Heli_Attack_02_black_F"
-	,"O_Heli_Light_02_F"];
+	,"O_Heli_Attack_02_black_F"];
 a3e_arr_O_transport_heli = [
 	"O_Heli_Light_02_unarmed_F"];
 	if(Param_UseDLCHelis==1) then {
@@ -860,16 +859,9 @@ a3e_arr_searchdrone = [
 // Two arrays for "Easy" and "Hard" parameter, both used on stadard setting
 //////////////////////////////////////////////////////////////////
 a3e_arr_searchChopperEasy = [
-	"I_Heli_light_03_unarmed_F"
-	,"I_Heli_Transport_02_F"
-	,"O_Heli_Light_02_unarmed_F"];
-	if(Param_UseDLCHelis==1) then {
-	a3e_arr_searchChopperEasy pushback "O_Heli_Transport_04_F";
-	};
+	"I_Heli_light_03_unarmed_F"];
 a3e_arr_searchChopperHard = [
-	"I_Heli_light_03_F"
-	,"O_Heli_Light_02_F"
-	,"O_Heli_Light_02_v2_F"];
+	"I_Heli_light_03_F"];
 a3e_arr_searchChopper_pilot = [
 	"I_helipilot_F"];
 a3e_arr_searchChopper_crew = [


### PR DESCRIPTION
The UnitClasses.sqf file for many of the versions could use some updates, and I've started with three sections that I felt were most in need of it, which are Comcenter defense, helicoopters, and UAV.

These three sections were key points of balance that I felt needed some adjustment.  My primary goals were to make these consistent with each other in regards to difficulty, while still retaining each mods unique feel and unit types.  There were also a few units of the wrong side/type/etc that I wanted to fix when necessary.

Comcenter defense: I focused on removing heavily armored AA units away from the light classes into the heavy classes and ensuring the light classes were primarily heavily armored cars and wheeled APCs without tank turrets.  These changes will ensure a smoother difficulty curve for the different player count settings, and less differences in difficulty between versions.

Attack and Transport Helicopters:  I removed all light attack helicopters from the "a3e_arr_O_attack_heli" version and only kept dedicated attack helicopters such as the Hind and the Blackfoot.  Attack helicopters seemed to almost never spawn and usually it was because light helicopters outnumbered them in the class lists by 3 to 1 or more.  I've done some testing and attack helicopters are more frequent, but I think it should be manageable for players.  For transport helicopters I generally made light changes and tried to chose larger helicopters when possible.

Extraction Helicopters: I removed any and all helicopters that do not have flares or are unarmed (with the exception of the CSAT DLC helicopter with the bench because it's so fun), and emphasized helicopters with heavy armor and armament when possible.  This will greatly increase the extraction helicopters survivability.

Search Helicopters: I emphasized removing the larger armed and unarmored search helicopters since they can have trouble following players and are harder for the players to shoot down.  It also makes more sense to use light helicopters as scout helicopters.

UAV: For this I focused on removing erroneous classnames and also tried to keep the factions more consistent.  For example, it didn't make much sense for the Takistani's to use a heavily armed drone from the base game, so I gave them the unarmed Russian drone from CUP as a replacement.


Detailed Change Notes:

APEX CSAT VS NATO

Attack and Transport Helicopter: removed light helicopter from attack option and matched apex transport helis to vanilla

APEX NATO VS CSAT

com center changes: moved AA to heavy and changed classname of Marid wheeled APC

Attack and Transport Helicopter: removed light attack helicopter from attack

extraction chopper: moved huron to dlc and added ghost hawk

BIS CSAT VS NATO

Com center changes: removed RHINO from light and moved AA to heavy; added one more GMG mrap; removed erroneous CSAT tanks

Attack and Transport Helicopter: removed light helicopter

Extraction chopper: replaced with Mi-48 Kajman's and removed covered DLC helicopter

search chopper: removed blufor helicopters and AAF heavy transport chopper

BIS NATO VS CSAT

com center changes moved AA from light to heavy

Attack and Transport Helicopter: removed light attack helicopter from attack

search chopper changes: same as CSAT VS NATO

CUP GER VS TAKI 

comcenter changes: added ZU-23

Com center static weapons: changed indep units to opfor units

Attack and Transport Helicopter: removed light attack helicopter; changed independent pilots from opfor to indep units

Extraction Chopper: changed from US helicopters to German

UAV: changed to Russian drone

CUP RU VS BAF WOODLAND

comcenter changes: removed land rover, ridgeback lmg, jackal, coyote, mastiff, and ION SUV

Attack and Transport Helicopter: removed light attack helicopters and indep helicopters from attack helicopters

Extraction Chopper: removed KA60 and MI6T because both have no flares and the MI6T is simply too large.  also removed medivac heli.  added mi24 as extraction chopper possibility

UAV: removed plane (doesn't function as a UAV) and AH6X

CUP RU VS BAF DESERT

comcenter changes: same as RU VS BAF Woodland except changed camos to desert

Com center static weapons: changed unit camo from mtp to desert

Attack and Transport Helicopters: same as RU VS BAF WOODLAND except removing ACR helis instead of ION

Extraction Chopper: same as RU VS BAF WOODLAND

UAV: same as RU VS BAF Woodland except there's no plane

search chopper changes: changed easy search choppers because current ones have weapons (they're labelled as unarmed in the editor when they're in fact armed); changed hard helicopters to british only

CUP RU VS CDF

comcenter changes: removed tracked vehicles and HQ versions from light; added BRDM2 ATGM

Attack and Transport Helicopter: removed indep helicopters and Mi-24D MEV

Extraction Chopper: same as CUP RU VS BAF versions

search chopper changes: changed pilots to winter versions

CUP RU VS US ARMY

comcenter changes: light: removed all humvees, m1135, m1128 and added RG-31s; added M1135 ATGMV AND RG31 M2 GC; removed non reactive armor bradleys; changed woodland camo tanks to desert

Attack and Transport Helicopter: removed all but AH-64D from attack

Extraction Chopper: same as CUP RU VS BAF versions

UAV: removed ION plane

CUP SLA VS USMC

comcenter changes: removed humvees and AAV, more RG-31s

Attack and Transport Helicopter: removed light attack helicopters from attack changed indep transport heli to takistani (National Party of Chernarus doesn't have a helicopter)

Extraction Chopper: removed uh1h and Mi8 sla 1 and added mi24

search chopper changes: removed ch53 and UH1Y MEV from easy and added seahawk m3m and updated classes on hard

CUP USMC VS RU

Prison guards: added additional aks74 soldier

comcenter changes: removed vodniks and Indep BDRM from light and added new bdrms, btrs, and vodnik bppu, removed bmps and ts2 from heavy and added t90

Attack and Transport Helicopter: removed ka-60 from attack helicopters; removed ViV from Opfor transports; removed RACS helicopters and added russian helicopters to indep faction because NAPA doesn't have any helicopters and russian helis make more sense

Extraction Chopper:  removed all US Army and unarmed helicopters, added several other armed variants, removed AH-64 escort

CUP USMC VS SLA

comcenter changes: removed indep unit from light; added btr60 to light; removed bmp from heavy

Com center static weapons: changed indep turret to opfor

Attack and Transport Helicopter: added mi-24 to attack; added mi6t to opfor transport; added CH47 and new UH60 variants to indep transport

Extraction Chopper:  same as CUP USMC VS RU

UAV: removed american drones and RACS c130j and added russian drone instead

search chopper changes: Removed sa-330 from easy search choppers; removed ch-47 from hard search choppers