### PR TITLE
Removed duplicate motorized search group entry

### DIFF
--- a/Code/Scripts/Escape/EscapeSurprises.sqf
+++ b/Code/Scripts/Escape/EscapeSurprises.sqf
@@ -125,8 +125,6 @@ while {true} do {
                     } else {
                         diag_log "ESCAPE SURPRISE: Unable to find spawn road for Motorized Searchgroup";
                     };
-                    [getPos _spawnSegment, drn_searchAreaMarkerName, _enemyFrequency, _enemyMinSkill, _enemyMaxSkill, A3E_Debug] execVM "Scripts\Escape\CreateMotorizedSearchGroup.sqf";
-                    
                     _surpriseArgs = [_minEnemySkill, _maxEnemySkill];
                     _timeInSek = 20 * 60 + random (60 * 60);
                     _timeInSek = time + _timeInSek * (4 - _enemyFrequency);


### PR DESCRIPTION
I discovered that motorized search group in EscapeSurprises.sqf was always spawning 2 vehicles that spawned into each other and exploded as a result.

Credit goes to John Jordan from discord for finding the duplicate line that caused the bug.