### PR TITLE
Remove motorized search group from fn_initserver.sqf

### DIFF
--- a/Code/functions/Server/fn_initServer.sqf
+++ b/Code/functions/Server/fn_initServer.sqf
@@ -224,20 +224,6 @@ private _UseMotorPools = Param_MotorPools;
 // Initialize search leader
 [drn_searchAreaMarkerName, A3E_Debug] execVM "Scripts\Escape\SearchLeader.sqf";
 
-// Create motorized search group
-
-[_enemyFrequency, _enemyMinSkill, _enemyMaxSkill] spawn {
-	params ["_enemyFrequency", "_enemyMinSkill", "_enemyMaxSkill"];
-	private _spawnSegment = [] call A3E_fnc_FindSpawnRoad;
-	
-	if(!isNull _spawnSegment) then {
-		[getPos _spawnSegment, drn_searchAreaMarkerName, _enemyFrequency, _enemyMinSkill, _enemyMaxSkill, A3E_Debug] execVM "Scripts\Escape\CreateMotorizedSearchGroup.sqf";
-	} else {
-		diag_log "Unable to find spawn road for initial Motorized Searchgroup";
-	};
-};
-
-
 // Start garbage collector
 [_playerGroup, 750, A3E_Debug] spawn drn_fnc_CL_RunGarbageCollector;
 


### PR DESCRIPTION
With the escape surprises motorized search group working properly now, leaving in this is redundant and in my opinion adds an unnecessary difficulty spike, especially when war torn is disabled.