### PR TITLE
fix tembelan fog issue

### DIFF
--- a/Missions/Tembelan/mission.sqm
+++ b/Missions/Tembelan/mission.sqm
@@ -93,8 +93,6 @@ class Mission
 		day=5;
 		hour=11;
 		minute=0;
-		startFogBase=250;
-		forecastFogBase=250;
 		startFogDecay=0.014;
 		forecastFogDecay=0.014;
 	};


### PR DESCRIPTION
tembelan island spawns with unplayably thick fog the majority of the time.  removing these lines fixes it