### PR TITLE
CUP RU vs USMC and RACS with new smgs and shotguns

### DIFF
--- a/Code/functions/Server/fn_initServer.sqf
+++ b/Code/functions/Server/fn_initServer.sqf
@@ -419,6 +419,10 @@ private _UseMotorPools = Param_MotorPools;
 			}];
 		} foreach _crew;
 		
+		clearitemcargoglobal _vehicle;
+        clearWeaponCargoGlobal _vehicle;
+        clearMagazineCargoGlobal _vehicle;			
+		
 		if (random 100 < 20) then {
 			private ["_weaponItem"];
 			
@@ -426,6 +430,15 @@ private _UseMotorPools = Param_MotorPools;
 			
 			_vehicle addWeaponCargoGlobal [_weaponItem select 0, 1];
 			_vehicle addMagazineCargoGlobal [_weaponItem select 1, _weaponItem select 2];
+		};	
+		if (random 100 < 80) then {
+           _vehicle addItemCargoglobal ["firstaidkit", 3];	
+		};
+		if (random 100 < 80) then {
+           _vehicle addMagazineCargoglobal ["smokeshellRed", 2];	
+		};
+		if (random 100 < 80) then {
+           _vehicle addMagazineCargoglobal ["Chemlight_green", 5];	
 		};
 	};
 	
@@ -600,7 +613,7 @@ waitUntil {scriptDone _scriptHandle};
 					_unit unlinkItem _hmd;
 				};
             };
-            
+	
             //_unit setSkill a3e_var_Escape_enemyMinSkill;
 			//[_unit, a3e_var_Escape_enemyMinSkill] call EGG_EVO_skill;
 			

--- a/Configs/CUP.json
+++ b/Configs/CUP.json
@@ -160,6 +160,26 @@
 					"PLAYERUNIT_9" : "CUP_O_RU_Soldier",
 					"PLAYERUNIT_10" : "CUP_O_RU_Medic"
 				}
+		},
+		{
+			"name" : "CUP RU vs USMC-RACS",
+			"path" : "./Mods/CUP RU vs USMC-RACS/",
+			"require" : ["CUP_Creatures_Military_RACS","CUP_Creatures_Military_USMC","CUP_Creatures_Military_Russia"],
+			"replace" :
+				{
+					"MOD" : "CUP RU vs USMC and RACS",
+					"PLAYERSIDE" : "EAST",
+					"PLAYERUNIT_1" : "CUP_O_RU_Officer_EMR",
+					"PLAYERUNIT_2" : "CUP_O_RU_Soldier_GL_EMR",
+					"PLAYERUNIT_3" : "CUP_O_RU_Soldier_Marksman_EMR",
+					"PLAYERUNIT_4" : "CUP_O_RU_Engineer_EMR",
+					"PLAYERUNIT_5" : "CUP_O_RU_Soldier_AA_EMR",
+					"PLAYERUNIT_6" : "CUP_O_RU_Soldier_AR_EMR",
+					"PLAYERUNIT_7" : "CUP_O_RU_Soldier_AT_EMR",
+					"PLAYERUNIT_8" : "CUP_O_RU_Soldier_MG_EMR",
+					"PLAYERUNIT_9" : "CUP_O_RU_Soldier_EMR",
+					"PLAYERUNIT_10" : "CUP_O_RU_Medic_EMR"
+				}
 		}
 	],
 	"Islands": [],
@@ -186,6 +206,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Altis",
+			"sqm": "Altis",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Stratis",
 			"sqm": "Stratis",
 			"mod" : "CUP-US USMC",
@@ -205,6 +232,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Stratis",
+			"sqm": "Stratis",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Tanoa",
@@ -228,6 +262,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Tanoa",
+			"sqm": "Tanoa",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Malden 2035",
 			"sqm": "Malden",
 			"mod" : "CUP-US USMC",
@@ -247,6 +288,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Malden 2035",
+			"sqm": "Malden",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Bornholm",
@@ -270,6 +318,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Bornholm",
+			"sqm": "Bornholm",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Chernarus",
 			"sqm": "Chernarus",
 			"mod" : "CUP-US USMC",
@@ -289,6 +344,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Chernarus",
+			"sqm": "Chernarus",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Chernarus_Summer",
@@ -312,6 +374,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Chernarus_Summer",
+			"sqm": "Chernarus_Summer",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Livonia",
 			"sqm": "Enoch",
 			"mod" : "CUP-US USMC",
@@ -331,6 +400,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Livonia",
+			"sqm": "Enoch",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Chernarus_Winter",
@@ -361,6 +437,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Podagorsk",
+			"sqm": "FDF_Isle1_a",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Panthera",
 			"sqm": "Panthera3",
 			"mod" : "CUP-US USMC",
@@ -380,6 +463,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Panthera",
+			"sqm": "Panthera3",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Winter Panthera",
@@ -403,6 +493,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Winter Panthera",
+			"sqm": "Winthera3",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Lingor",
 			"sqm": "Lingor3",
 			"mod" : "CUP-US USMC",
@@ -422,6 +519,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Lingor",
+			"sqm": "Lingor3",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Dingor",
@@ -466,6 +570,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Abramia",
+			"sqm": "Abramia",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Celle",
 			"sqm": "mbg_celle2",
 			"mod" : "CUP-US USMC",
@@ -485,6 +596,20 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Celle",
+			"sqm": "mbg_celle2",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
+			"island" : "Abramia",
+			"sqm": "Abramia",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Thirsk",
@@ -508,6 +633,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Thirsk",
+			"sqm": "Thirsk",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Esseker",
 			"sqm": "Esseker",
 			"mod" : "CUP-US USMC",
@@ -527,6 +659,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Esseker",
+			"sqm": "Esseker",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Australia",
@@ -569,6 +708,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Thirsk Winter",
+			"sqm": "ThirskW",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Isla Duala",
@@ -619,7 +765,7 @@
 			"replace" : {},
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
 		},
-				{
+		{
 			"island" : "Zargabad",
 			"sqm": "Zargabad",
 			"mod" : "CUP Taki",
@@ -690,6 +836,13 @@
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
 		},
 		{
+			"island" : "Everon",
+			"sqm": "Eden",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Malden",
 			"sqm": "Abel",
 			"mod" : "CUP RU",
@@ -709,6 +862,13 @@
 			"mod" : "CUP-BAF w",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
+		},
+		{
+			"island" : "Malden",
+			"sqm": "Abel",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Kolgujev",
@@ -732,6 +892,13 @@
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
 		},
 		{
+			"island" : "Kolgujev",
+			"sqm": "Cain",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Nogova",
 			"sqm": "Noe",
 			"mod" : "CUP RU",
@@ -751,6 +918,13 @@
 			"mod" : "CUP-BAF w",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
+		},
+		{
+			"island" : "Nogova",
+			"sqm": "Noe",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Beketov",
@@ -774,6 +948,13 @@
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
 		},
 		{
+			"island" : "Beketov",
+			"sqm": "Beketov",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Isles of Cumbrae",
 			"sqm": "rof_isles_of_cumbrae",
 			"mod" : "CUP RU",
@@ -793,6 +974,13 @@
 			"mod" : "CUP-BAF w",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
+		},
+		{
+			"island" : "Isles of Cumbrae",
+			"sqm": "rof_isles_of_cumbrae",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Schwemlitz",
@@ -835,6 +1023,20 @@
 			"mod" : "CUP-BAF w",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_RU_vs_BAF"
+		},
+		{
+			"island" : "Rosche",
+			"sqm": "Rosche",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
+			"island" : "Schwemlitz",
+			"sqm": "Schwemlitz",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Clafghan",
@@ -942,6 +1144,13 @@
 			"name" : "co10_Escape_CUP_SLA_vs_USMC"
 		},
 		{
+			"island" : "Sahrani",
+			"sqm": "Sara",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "United Sahrani",
 			"sqm": "Sara_dbe1",
 			"mod" : "CUP SLA",
@@ -956,6 +1165,13 @@
 			"name" : "co10_Escape_CUP_SLA_vs_USMC"
 		},
 		{
+			"island" : "United Sahrani",
+			"sqm": "Sara_dbe1",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Diyala",
 			"sqm": "DYA",
 			"mod" : "CUP-US Army d",
@@ -998,6 +1214,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Kastellorizo",
+			"sqm": "Kastellorizo",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Kerama",
 			"sqm": "Kerama",
 			"mod" : "CUP-US USMC",
@@ -1017,6 +1240,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Kerama",
+			"sqm": "Kerama",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Valtatie 5",
@@ -1040,6 +1270,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Valtatie 5",
+			"sqm": "VT5",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Ruha",
 			"sqm": "Ruha",
 			"mod" : "CUP-US USMC",
@@ -1061,6 +1298,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Ruha",
+			"sqm": "Ruha",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Prei Khmaoch Luong",
 			"sqm": "prei_khmaoch_luong",
 			"mod" : "CUP-US USMC",
@@ -1080,6 +1324,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Prei Khmaoch Luong",
+			"sqm": "prei_khmaoch_luong",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Porto",
@@ -1145,6 +1396,13 @@
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
 		},
 		{
+			"island" : "Yellowstone",
+			"sqm": "yellowstone",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
+		},
+		{
 			"island" : "Tembelan",
 			"sqm": "Tembelan",
 			"mod" : "CUP-US USMC",
@@ -1164,6 +1422,13 @@
 			"mod" : "CUP RU",
 			"replace" : {},
 			"name" : "co10_Escape_CUP_USMC_vs_RU"
+		},
+		{
+			"island" : "Tembelan",
+			"sqm": "Tembelan",
+			"mod" : "CUP RU vs USMC-RACS",
+			"replace" : {},
+			"name" : "co10_Escape_CUP_RU_vs_USMC_and_RACS"
 		},
 		{
 			"island" : "Kujari",
@@ -1190,7 +1455,7 @@
 	"Addons" : [
 		{
 			"name" : "CUP",
-			"mods" : ["CUP SLA","CUP-US Army d","CUP-BAF d","CUP-BAF w","CUP RU","CUP Taki","CUP-US USMC","CUP-CDF Winter"]
+			"mods" : ["CUP SLA","CUP-US Army d","CUP-BAF d","CUP-BAF w","CUP RU","CUP Taki","CUP-US USMC","CUP-CDF Winter","CUP RU vs USMC-RACS"]
 		}
 	]
 	

--- a/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
@@ -1,0 +1,1374 @@
+/*
+ * Description: This file contains the vehicle types and unit types for the units spawned in the mission, and the weapons and magazines found in ammo boxes/cars.
+ * "Random array" (used below) means that array will be used to spawn units, and that chance is 1/n that each element will be spawned on each spawn. The array can contain 
+ * many elements of the same type, so the example array ["Offroad_DSHKM_INS", "Pickup_PK_INS", "Pickup_PK_INS"] will spawn an Offroad with 1/3 probability, and a 
+ * Pickup with 2/3 probability.
+ */
+
+private ["_enemyFrequency"];
+
+_enemyFrequency = _this select 0;
+
+//Sides
+
+A3E_VAR_Side_Blufor = east;//Player side CUP SLA
+A3E_VAR_Side_Opfor = west;//Enemy side CUP USMC woodland
+A3E_VAR_Side_Ind = resistance;//Independent side CUP RACS
+
+A3E_VAR_Flag_Opfor = "\A3\Data_F\Flags\Flag_us_CO.paa";
+A3E_VAR_Flag_Ind = "\A3\Data_F\Flags\Flag_green_CO.paa";
+
+A3E_VAR_Side_Blufor_Str = format["%1",A3E_VAR_Side_Blufor];
+A3E_VAR_Side_Opfor_Str = format["%1",A3E_VAR_Side_Opfor];
+A3E_VAR_Side_Ind_Str = format["%1",A3E_VAR_Side_Ind];
+
+// Random array. Start position guard types around the prison.
+a3e_arr_Escape_StartPositionGuardTypes = [
+	"CUP_I_RACS_Soldier_wdl"
+	,"CUP_I_RACS_Soldier_Light_wdl"
+	,"CUP_I_RACS_GL_wdl"
+	,"CUP_I_RACS_AR_wdl"];
+
+// Prison backpack secondary weapon (and corresponding magazine type).
+a3e_arr_PrisonBackpackWeapons = [];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911_snds","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911_snds","CUP_7Rnd_45ACP_1911"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9_snds","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9_snds","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17_blk","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_flashlight_snds","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_snds","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_flashlight","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_flashlight_snds","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_snds","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mk23","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_12Rnd_45ACP_mk23"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455_gold","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455_gold","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5_flashlight","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5SD6","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5_flashlight","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5SD6","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Beneli_74Pellets"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Benelli_74Slug"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Beneli_74Pellets"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Benelli_74Slug"];
+
+
+// Random array. Civilian vehicle classes for ambient traffic.
+a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
+	"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_camo_Civ"
+	,"CUP_C_Golf4_camodark_Civ"
+	,"CUP_C_Golf4_camodigital_Civ"
+	,"CUP_C_Golf4_crowe_Civ"
+	,"CUP_C_Golf4_kitty_Civ"
+	,"CUP_C_Golf4_reptile_Civ"
+	,"CUP_C_Golf4_whiteblood_Civ"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_TT650_RU"
+	,"CUP_C_TT650_RU"
+	,"CUP_C_TT650_RU"
+    ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_TT650_TK"
+	,"CUP_C_TT650_TK"
+	,"CUP_C_TT650_TK"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"];
+
+// Random arrays. Enemy vehicle classes for ambient traffic.
+// Variable _enemyFrequency applies to server parameter, and can be one of the values 1 (Few), 2 (Some) or 3 (A lot).
+switch (_enemyFrequency) do {
+    case 1: {//Few (1-3)
+        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
+		//Unarmed cars  4 sets
+		"CUP_B_M1030_USMC"  //1
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"  //2
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"   //3
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"  //4
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		//Supply Trucks  3 sets
+		,"CUP_B_MTVR_Ammo_USMC"  //1
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		,"CUP_B_MTVR_Ammo_USMC"  //2
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		,"CUP_B_MTVR_Ammo_USMC"  //3
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		//Unarmed APCs  1 set
+		,"CUP_B_AAV_Unarmed_USMC"
+		,"CUP_B_AAV_Unarmed_USMC"
+		,"CUP_B_AAV_Unarmed_USMC"
+		//Armed Cars  1 set
+		,"CUP_B_HMMWV_Avenger_USMC"
+		,"CUP_B_HMMWV_M1114_USMC"
+		,"CUP_B_HMMWV_MK19_USMC"
+		,"CUP_B_HMMWV_TOW_USMC"
+		,"CUP_B_HMMWV_M2_USMC"
+		,"CUP_B_M1151_M2_USMC"
+		,"CUP_B_M1151_Deploy_USMC"
+		,"CUP_B_M1151_Mk19_USMC"
+		,"CUP_B_M1165_GMV_USMC"
+		,"CUP_B_M1167_USMC"
+		//MRAPs  1 set
+		,"CUP_B_RG31_Mk19_OD_USMC"
+		,"CUP_B_RG31E_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_GC_USMC"
+		//Light Armed APCs  1 set
+		,"CUP_B_LAV25_HQ_USMC"
+		,"CUP_B_LAV25_HQ_USMC"
+		,"CUP_B_LAV25_HQ_USMC"
+		//Heavily Armed APCs or AA  1 set
+		,"CUP_B_AAV_USMC"
+		,"CUP_B_LAV25_USMC"
+		,"CUP_B_LAV25M240_USMC"
+		//Artillery  1 set
+		,"CUP_B_M270_HE_USMC"
+		,"CUP_B_M270_DPICM_USMC"
+		//Tanks  1 set
+		,"CUP_B_M1A1_Woodland_USMC"
+		,"CUP_B_M1A2_TUSK_MG_USMC"];
+        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars  1 set 
+		"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		//Unarmed APCs  2 sets
+		,"CUP_I_AAV_Unarmed_RACS"  //1
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_AAV_Unarmed_RACS"  //2
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_M113_Med_RACS"
+		//Armed Cars  1 set
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		//Light Armed APCs  2 sets
+		,"CUP_I_LAV25_HQ_RACS"  //1
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		,"CUP_I_LAV25_HQ_RACS"  //2
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		//Heavily Armed APCs or AA  1 set
+		,"CUP_I_M163_RACS"
+		,"CUP_I_AAV_RACS"
+		,"CUP_I_LAV25_RACS"
+		,"CUP_I_LAV25M240_RACS"
+		//Tanks  1 set
+		,"CUP_I_M60A3_RACS"
+		,"CUP_I_M60A3_TTS_RACS"
+		,"CUP_I_T72_RACS"];
+    };
+    case 2: {//Some (4-6)
+        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
+		//Unarmed cars  3 sets
+		"CUP_B_M1030_USMC"  //1
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"  //2
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"  //3
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		//Supply Trucks  3 sets
+		,"CUP_B_MTVR_Ammo_USMC"  //1
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		,"CUP_B_MTVR_Ammo_USMC"  //2
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		,"CUP_B_MTVR_Ammo_USMC"  //3
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		//Unarmed APCs  2 sets
+		,"CUP_I_AAV_Unarmed_RACS"  //1
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_AAV_Unarmed_RACS"  //2
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_M113_Med_RACS"
+		//Armed Cars  2 sets
+		,"CUP_B_HMMWV_Avenger_USMC"  //1
+		,"CUP_B_HMMWV_M1114_USMC"
+		,"CUP_B_HMMWV_MK19_USMC"
+		,"CUP_B_HMMWV_TOW_USMC"
+		,"CUP_B_HMMWV_M2_USMC"
+		,"CUP_B_M1151_M2_USMC"
+		,"CUP_B_M1151_Deploy_USMC"
+		,"CUP_B_M1151_Mk19_USMC"
+		,"CUP_B_M1165_GMV_USMC"
+		,"CUP_B_M1167_USMC"
+		,"CUP_B_HMMWV_Avenger_USMC"  //2
+		,"CUP_B_HMMWV_M1114_USMC"
+		,"CUP_B_HMMWV_MK19_USMC"
+		,"CUP_B_HMMWV_TOW_USMC"
+		,"CUP_B_HMMWV_M2_USMC"
+		,"CUP_B_M1151_M2_USMC"
+		,"CUP_B_M1151_Deploy_USMC"
+		,"CUP_B_M1151_Mk19_USMC"
+		,"CUP_B_M1165_GMV_USMC"
+		,"CUP_B_M1167_USMC"
+		//MRAPs  2 sets
+		,"CUP_B_RG31_Mk19_OD_USMC"  //1
+		,"CUP_B_RG31E_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_GC_USMC"
+		,"CUP_B_RG31_Mk19_OD_USMC"  //2
+		,"CUP_B_RG31E_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_GC_USMC"
+		//Light Armed APCs  1 set
+		,"CUP_B_LAV25_HQ_USMC"
+		,"CUP_B_LAV25_HQ_USMC"
+		,"CUP_B_LAV25_HQ_USMC"
+		//Armed APCs or AA  1 set  
+		,"CUP_B_AAV_USMC"
+		,"CUP_B_LAV25_USMC"
+		,"CUP_B_LAV25M240_USMC"
+		//Artillery  1 set
+		,"CUP_B_M270_HE_USMC"
+		,"CUP_B_M270_DPICM_USMC"
+		//Tanks  1 set
+		,"CUP_B_M1A1_Woodland_USMC"
+		,"CUP_B_M1A2_TUSK_MG_USMC"];
+        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars  1 set
+		"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		//Unarmed APCs  2 sets
+		,"CUP_I_AAV_Unarmed_RACS"  //1
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_AAV_Unarmed_RACS"  //2
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		//Armed Cars  2 sets
+		,"CUP_I_LR_MG_RACS"  //1
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"  //2
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		//Light Armed APCs  4 sets
+		,"CUP_I_LAV25_HQ_RACS"  //1
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		,"CUP_I_LAV25_HQ_RACS"  //2
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"  
+		,"CUP_I_LAV25_HQ_RACS"  //3
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"  
+		,"CUP_I_LAV25_HQ_RACS"  //4
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		//Heavily Armed APCs or AA  1 set
+		,"CUP_I_M163_RACS"
+		,"CUP_I_AAV_RACS"
+		,"CUP_I_LAV25_RACS"
+		,"CUP_I_LAV25M240_RACS"
+		//Tanks  1 set
+		,"CUP_I_M60A3_RACS"
+		,"CUP_I_M60A3_TTS_RACS"
+		,"CUP_I_T72_RACS"];
+    };
+    default {//A lot (7-8)
+        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
+		//Unarmed cars  3 sets
+		"CUP_B_M1030_USMC"  //1
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"  //2
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		,"CUP_B_M1030_USMC"  //3
+		,"CUP_B_HMMWV_Ambulance_USMC"
+		,"CUP_B_HMMWV_Unarmed_USMC"
+		,"CUP_B_M1151_USMC"
+		,"CUP_B_M1152_USMC"
+		,"CUP_B_MTVR_USMC"
+		//Supply Trucks  3 sets
+		,"CUP_B_MTVR_Ammo_USMC"  //1
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		,"CUP_B_MTVR_Ammo_USMC"  //2
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		,"CUP_B_MTVR_Ammo_USMC"  //3
+		,"CUP_B_MTVR_Refuel_USMC"
+		,"CUP_B_MTVR_Repair_USMC"
+		//Unarmed APCs  1 set
+		,"CUP_B_AAV_Unarmed_USMC"
+		,"CUP_B_AAV_Unarmed_USMC"
+		,"CUP_B_AAV_Unarmed_USMC"
+		//Armed Cars  2 sets
+		,"CUP_B_HMMWV_Avenger_USMC"  //1
+		,"CUP_B_HMMWV_M1114_USMC"
+		,"CUP_B_HMMWV_MK19_USMC"
+		,"CUP_B_HMMWV_TOW_USMC"
+		,"CUP_B_HMMWV_M2_USMC"
+		,"CUP_B_M1151_M2_USMC"
+		,"CUP_B_M1151_Deploy_USMC"
+		,"CUP_B_M1151_Mk19_USMC"
+		,"CUP_B_M1165_GMV_USMC"
+		,"CUP_B_M1167_USMC"
+		,"CUP_B_HMMWV_Avenger_USMC"  //2
+		,"CUP_B_HMMWV_M1114_USMC"
+		,"CUP_B_HMMWV_MK19_USMC"
+		,"CUP_B_HMMWV_TOW_USMC"
+		,"CUP_B_HMMWV_M2_USMC"
+		,"CUP_B_M1151_M2_USMC"
+		,"CUP_B_M1151_Deploy_USMC"
+		,"CUP_B_M1151_Mk19_USMC"
+		,"CUP_B_M1165_GMV_USMC"
+		,"CUP_B_M1167_USMC"
+		//MRAPs  2 sets
+		,"CUP_B_RG31_Mk19_OD_USMC"  //1
+		,"CUP_B_RG31E_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_GC_USMC"
+		,"CUP_B_RG31_Mk19_OD_USMC"  //2
+		,"CUP_B_RG31E_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_GC_USMC"
+		//Light Armed APCs  1 set
+		,"CUP_B_LAV25_HQ_USMC"
+		,"CUP_B_LAV25_HQ_USMC"
+		,"CUP_B_LAV25_HQ_USMC"
+		//Heavily Armed APCs or AA  2 sets 
+		,"CUP_B_AAV_USMC"  //1
+		,"CUP_B_LAV25_USMC"
+		,"CUP_B_LAV25M240_USMC"
+		,"CUP_B_AAV_USMC"  //2
+		,"CUP_B_LAV25_USMC"
+		,"CUP_B_LAV25M240_USMC"
+		//Artillery  1 set
+		,"CUP_B_M270_HE_USMC"
+		,"CUP_B_M270_DPICM_USMC"
+		//Tanks  2 sets
+		,"CUP_B_M1A1_Woodland_USMC"  //1
+		,"CUP_B_M1A2_TUSK_MG_USMC"
+		,"CUP_B_M1A1_Woodland_USMC"  //2
+		,"CUP_B_M1A2_TUSK_MG_USMC"];
+        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars  1 set
+		"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Ambulance_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		,"CUP_I_LR_Transport_RACS"
+		//Unarmed APCs  2 sets
+		,"CUP_I_AAV_Unarmed_RACS"  //1
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		,"CUP_I_AAV_Unarmed_RACS"  //2
+		,"CUP_I_AAV_Unarmed_RACS"
+		,"CUP_I_M113_Med_RACS"
+		//Armed Cars  2 sets
+		,"CUP_I_LR_MG_RACS"  //1
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"  //2
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		,"CUP_I_LR_MG_RACS"
+		//Light Armed APCs  4 sets
+		,"CUP_I_LAV25_HQ_RACS"  //1
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		,"CUP_I_LAV25_HQ_RACS"  //2
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		,"CUP_I_LAV25_HQ_RACS"  //3
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		,"CUP_I_LAV25_HQ_RACS"  //4
+		,"CUP_I_M113_RACS"
+		,"CUP_I_M113_RACS_URB"
+		//Heavily Armed APCs or AA  2 sets
+		,"CUP_I_M163_RACS"  //1
+		,"CUP_I_AAV_RACS"
+		,"CUP_I_LAV25_RACS"
+		,"CUP_I_LAV25M240_RACS"
+		,"CUP_I_M163_RACS"  //2
+		,"CUP_I_AAV_RACS"
+		,"CUP_I_LAV25_RACS"
+		,"CUP_I_LAV25M240_RACS"
+		//Tanks  2 sets
+		,"CUP_I_M60A3_RACS"  //1
+		,"CUP_I_M60A3_TTS_RACS"
+		,"CUP_I_T72_RACS"
+		,"CUP_I_M60A3_RACS"  //2
+		,"CUP_I_M60A3_TTS_RACS"
+		,"CUP_I_T72_RACS"];
+    };
+};
+
+// Random array. General infantry types. E.g. village patrols, ambient infantry, ammo depot guards, communication center guards, etc.
+a3e_arr_Escape_InfantryTypes = [
+	"CUP_B_USMC_Soldier"
+	,"CUP_B_USMC_Soldier"
+	,"CUP_B_USMC_Soldier"
+	,"CUP_B_USMC_Soldier"
+	,"CUP_B_USMC_Soldier_GL"
+	,"CUP_B_USMC_Soldier_GL"
+	,"CUP_B_USMC_Officer"
+	,"CUP_B_USMC_Soldier_SL"
+	,"CUP_B_USMC_Soldier_SL"
+	,"CUP_B_USMC_Soldier_TL"
+	,"CUP_B_USMC_Soldier_TL"
+	,"CUP_B_USMC_Soldier_LAT"
+	,"CUP_B_USMC_Soldier_LAT"
+	,"CUP_B_USMC_Soldier_HAT"
+	,"CUP_B_USMC_Soldier_AA"
+	,"CUP_B_USMC_Soldier_AA"
+	,"CUP_B_USMC_Medic"
+	,"CUP_B_USMC_Medic"
+	,"CUP_B_USMC_Soldier_AR"
+	,"CUP_B_USMC_Soldier_AR"
+	,"CUP_B_USMC_Soldier_AR"
+	,"CUP_B_USMC_Spotter"
+	,"CUP_B_USMC_Sniper_M40A3"
+	,"CUP_B_USMC_Sniper_M107"
+	,"CUP_B_USMC_Soldier_Marksman"
+	,"CUP_B_USMC_Engineer"
+	,"CUP_B_USMC_Engineer"
+	,"CUP_B_USMC_Soldier_AT"
+	,"CUP_B_USMC_Soldier_MG"
+	,"CUP_B_USMC_Soldier_MG"
+	,"CUP_B_USMC_Soldier_UAV"
+	,"CUP_B_USMC_SpecOps"
+	,"CUP_B_USMC_SpecOps_SD"];
+a3e_arr_Escape_InfantryTypes_Ind = [
+	"CUP_I_RACS_Soldier_AA_wdl"
+	,"CUP_I_RACS_Soldier_AA_wdl"
+	,"CUP_I_RACS_Soldier_AAT_wdl"
+	,"CUP_I_RACS_Soldier_AMG_wdl"
+	,"CUP_I_RACS_Soldier_AMG_wdl"
+	,"CUP_I_RACS_Soldier_MAT_wdl"
+	,"CUP_I_RACS_Soldier_MAT_wdl"
+	,"CUP_I_RACS_AR_wdl"
+	,"CUP_I_RACS_AR_wdl"
+	,"CUP_I_RACS_Engineer_wdl"
+	,"CUP_I_RACS_Engineer_wdl"
+	,"CUP_I_RACS_GL_wdl"
+	,"CUP_I_RACS_GL_wdl"
+	,"CUP_I_RACS_Soldier_HAT_wdl"
+	,"CUP_I_RACS_MMG_wdl"
+	,"CUP_I_RACS_MMG_wdl"
+	,"CUP_I_RACS_M_wdl"
+	,"CUP_I_RACS_Medic_wdl"
+	,"CUP_I_RACS_Medic_wdl"
+	,"CUP_I_RACS_Officer_wdl"
+	,"CUP_I_RACS_Officer_wdl"
+	,"CUP_I_RACS_Soldier_wdl"
+	,"CUP_I_RACS_Soldier_wdl"
+	,"CUP_I_RACS_Soldier_wdl"
+	,"CUP_I_RACS_Soldier_wdl"
+	,"CUP_I_RACS_Soldier_Light_wdl"
+	,"CUP_I_RACS_Soldier_Light_wdl"
+	,"CUP_I_RACS_Soldier_Light_wdl"
+	,"CUP_I_RACS_Soldier_Light_wdl"
+	,"CUP_I_RACS_Soldier_LAT_wdl"
+	,"CUP_I_RACS_Soldier_LAT_wdl"
+	,"CUP_I_RACS_Sniper_wdl"
+	,"CUP_I_RACS_SL_wdl"];
+a3e_arr_recon_InfantryTypes = [
+	"CUP_B_FR_Commander"
+	,"CUP_B_FR_Saboteur"
+	,"CUP_B_FR_Soldier_Marksman"
+	,"CUP_B_FR_Soldier_AR"
+	,"CUP_B_FR_Soldier_GL"
+	,"CUP_B_FR_Soldier_Exp"
+	,"CUP_B_FR_Soldier_Operator"
+	,"CUP_B_FR_Soldier_Assault_GL"
+	,"CUP_B_FR_Soldier_TL"
+	,"CUP_B_FR_Medic"
+	,"CUP_B_FR_Soldier_Assault"
+	,"CUP_B_FR_Soldier_UAV"];
+a3e_arr_recon_I_InfantryTypes = [
+	"CUP_I_RACS_RoyalCommando"
+	,"CUP_I_RACS_RoyalGuard"
+	,"CUP_I_RACS_RoyalMarksman"];
+
+// Random array. A roadblock has a manned vehicle. This array contains possible manned vehicles (can be of any kind, like cars, armored and statics).
+a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
+    "CUP_B_HMMWV_Avenger_USMC"
+	,"CUP_B_M1151_Deploy_USMC"   
+	,"CUP_B_M1151_Mk19_USMC"
+	,"CUP_B_M1165_GMV_USMC"
+	,"CUP_B_M1167_USMC"
+	,"CUP_B_RG31_Mk19_OD_USMC"
+	,"CUP_B_RG31_M2_OD_USMC"
+	,"CUP_B_RG31_M2_OD_GC_USMC"];
+a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind = [
+	"CUP_I_LR_MG_RACS"
+	,"CUP_I_LR_MG_RACS"
+	,"CUP_I_M113_RACS"
+	,"CUP_I_M163_RACS"];
+
+// Random array. Vehicle classes (preferrably trucks) transporting enemy reinforcements.
+a3e_arr_Escape_ReinforcementTruck_vehicleClasses = [
+	"CUP_B_MTVR_USMC"];
+a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind = [
+	"CUP_I_LR_Transport_RACS"];
+
+
+
+
+// Random array. Motorized search groups are sometimes sent to look for you. This array contains possible class definitions for the vehicles.
+a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
+	"CUP_B_RG31E_M2_OD_USMC"
+	,"CUP_B_AAV_USMC"
+	,"CUP_B_LAV25_USMC"
+	,"CUP_B_LAV25M240_USMC"];
+
+
+
+// A communication center is guarded by vehicles depending on variable _enemyFrequency. 1 = a random light armor. 2 = a random heavy armor. 3 = a random 
+// light *and* a random heavy armor.
+
+// Random array. Light armored vehicles guarding the communication centers.
+a3e_arr_ComCenDefence_lightArmorClasses = [
+	"CUP_B_RG31_M2_OD_GC_USMC"
+	,"CUP_B_RG31_M2_OD_GC_USMC"
+	,"CUP_B_RG31_Mk19_OD_USMC"
+	,"CUP_B_RG31_Mk19_OD_USMC"
+	,"CUP_B_LAV25_USMC"
+	,"CUP_B_LAV25M240_USMC"];
+// Random array. Heavy armored vehicles guarding the communication centers.
+a3e_arr_ComCenDefence_heavyArmorClasses = [
+	"CUP_B_M1A1_Woodland_USMC"
+	,"CUP_B_M1A2_TUSK_MG_USMC"];
+
+// A communication center contains two static weapons (in two corners of the communication center).
+// Random array. Possible static weapon types for communication centers.
+a3e_arr_ComCenStaticWeapons = [
+	"CUP_B_M2StaticMG_USMC"];
+// A communication center have two parked and empty vehicles of the following possible types.
+a3e_arr_ComCenParkedVehicles = [
+    "CUP_B_HMMWV_Ambulance_USMC"
+	,"CUP_B_MTVR_USMC"
+	,"CUP_B_MTVR_Ammo_USMC"
+	,"CUP_B_MTVR_Refuel_USMC"
+	,"CUP_B_MTVR_Repair_USMC"
+	,"CUP_B_HMMWV_Unarmed_USMC"
+	,"CUP_B_M1151_USMC"
+	,"CUP_B_M1152"
+	,"CUP_B_HMMWV_M1114_USMC"
+	,"CUP_B_HMMWV_MK19_USMC"
+	,"CUP_B_HMMWV_TOW_USMC"
+	,"CUP_B_HMMWV_M2_USMC"
+	,"CUP_B_M1151_Deploy_USMC"
+	,"CUP_B_M1151_Mk19_USMC"
+	,"CUP_B_M1152_USMC"
+	,"CUP_B_M1165_GMV_USMC"
+	,"CUP_B_M1167_USMC"
+	,"CUP_B_M1151_M2_USMC"
+	,"CUP_B_RG31_Mk19_OD_USMC"
+	,"CUP_B_RG31_M2_OD_USMC"
+	,"CUP_B_RG31E_M2_OD_USMC"
+	,"CUP_B_RG31_M2_OD_GC_USMC"
+	,"CUP_B_HMMWV_Avenger_USMC"
+	,"CUP_B_AAV_USMC"];
+
+// Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
+a3e_arr_Escape_EnemyCivilianCarTypes = [
+    "CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_camo_Civ"
+	,"CUP_C_Golf4_camodark_Civ"
+	,"CUP_C_Golf4_camodigital_Civ"
+	,"CUP_C_Golf4_crowe_Civ"
+	,"CUP_C_Golf4_kitty_Civ"
+	,"CUP_C_Golf4_reptile_Civ"
+	,"CUP_C_Golf4_whiteblood_Civ"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_TT650_RU"
+	,"CUP_C_TT650_RU"
+	,"CUP_C_TT650_RU"
+    ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_TT650_TK"
+	,"CUP_C_TT650_TK"
+	,"CUP_C_TT650_TK"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"];
+
+
+// Vehicles, weapons and ammo at ammo depots
+
+// Random array. An ammo depot contains one static weapon of the followin types:
+a3e_arr_Escape_AmmoDepot_StaticWeaponClasses = [
+	"CUP_B_M2StaticMG_USMC"];
+// An ammo depot have one parked and empty vehicle of the following possible types.
+a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
+
+//Random array. Types of helicopters to spawn
+a3e_arr_O_attack_heli = [
+	"CUP_B_AH1Z_Dynamic_USMC"];
+a3e_arr_O_transport_heli = [
+	"CUP_B_UH1Y_UNA_USMC"
+	,"CUP_B_MH60S_FFV_USMC"
+	,"CUP_B_UH60S_USN"
+	,"CUP_B_MH60S_USMC"
+	,"CUP_B_CH53E_USMC"
+	,"CUP_B_MV22_USMC"
+	,"CUP_B_MV22_USMC_RAMPGUN"];
+a3e_arr_O_pilots = [
+	"CUP_B_USMC_Pilot"];
+a3e_arr_I_transport_heli = [
+	"CUP_I_CH47F_RACS"
+	,"CUP_I_SA330_Puma_HC1_RACS"
+	,"CUP_I_SA330_Puma_HC2_RACS"
+	,"CUP_I_UH1H_RACS"
+	,"CUP_I_UH1H_Slick_RACS"
+	,"CUP_I_UH60L_RACS"
+	,"CUP_I_UH60L_FFV_RACS"
+	,"CUP_I_UH60L_Unarmed_RACS"
+	,"CUP_I_UH60L_Unarmed_FFV_Racs"];
+a3e_arr_I_pilots = [
+	"CUP_I_GUE_Pilot"];
+
+
+// The following arrays define weapons and ammo contained at the ammo depots
+// Index 0: Weapon classname.
+// Index 1: Weapon's probability of presence (in percent, 0-100).
+// Index 2: If weapon exists, crate contains at minimum this number of weapons of current class.
+// Index 3: If weapon exists, crate contains at maximum this number of weapons of current class.
+// Index 4: Array of magazine classnames. Magazines of these types are present if weapon exists.
+// Index 5: Number of magazines per weapon that exists.
+
+// Weapons and ammo in the basic weapons box
+a3e_arr_AmmoDepotBasicWeapons = [];
+// CSAT weapons
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_Colt1911", 50, 2, 5, ["CUP_7Rnd_45ACP_1911"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_M9", 50, 2, 5, ["CUP_15Rnd_9x19_M9"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_smg_MP5A5", 20, 1, 2, ["CUP_30Rnd_9x19_MP5"], 8];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A4_base", 100, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A4_grip", 100, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A4_GL", 75, 2, 4, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_black", 100, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1", 100, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_camo_carryhandle", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A3_black", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A3_camo", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_camo", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_BUIS_GL", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_GL_carryhandle", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_GL_carryhandle_camo", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M4A1_BUIS_camo_GL", 75, 3, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+// non-CSAT weapons
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_Glock17", 50, 2, 5, ["CUP_17Rnd_9x19_glock17"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_Glock17_flashlight", 50, 2, 5, ["CUP_17Rnd_9x19_glock17"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_Glock17_blk", 50, 2, 5, ["CUP_17Rnd_9x19_glock17"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A2", 50, 2, 5, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A2_GL", 75, 2, 4, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_G36C", 75, 3, 5, ["CUP_30Rnd_556x45_G36"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_G36A", 75, 3, 5, ["CUP_30Rnd_556x45_G36"], 6];
+
+
+// Weapons and ammo in the special weapons box
+a3e_arr_AmmoDepotSpecialWeapons = [];
+// CSAT weapons
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_M240", 20, 1, 2, ["CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Yellow_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], 4];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_M249", 50, 2, 4, ["CUP_200Rnd_TE4_Red_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Yellow_Tracer_556x45_M249"], 4];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_Mk12SPR", 50, 2, 4, ["CUP_20Rnd_556x45_Stanag"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_DMR", 50, 2, 4, ["CUP_20Rnd_762x51_DMR"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_M24_wdl", 50, 2, 4, ["CUP_5Rnd_762x51_M24"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_M24_blk", 50, 2, 4, ["CUP_5Rnd_762x51_M24"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_M40A3", 50, 2, 4, ["CUP_5Rnd_762x51_M24"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_sgun_M1014", 50, 1, 2, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_sgun_M1014_vfg", 50, 1, 2, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_sgun_M1014_solidstock", 50, 1, 2, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_sgun_M1014_Entry", 50, 1, 2, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_sgun_M1014_Entry_vfg", 50, 1, 2, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 10];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_M107_Base", 10, 1, 2, ["CUP_10Rnd_127x99_M107"], 8];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_M107_Pristine", 10, 1, 2, ["CUP_10Rnd_127x99_M107"], 8];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_M107_Woodland", 10, 1, 2, ["CUP_10Rnd_127x99_M107"], 8];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_glaunch_M32", 20, 1, 2, ["CUP_6Rnd_HE_M203"], 4];
+// non-CAST weapons
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_M249_E2", 20, 1, 2, ["CUP_200Rnd_TE4_Red_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Yellow_Tracer_556x45_M249"], 4];
+
+
+
+// Weapons and ammo in the launchers box
+a3e_arr_AmmoDepotLaunchers = [];
+// CSAT weapons
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Mk153Mod0", 50, 1, 3, ["CUP_SMAW_HEAA_M", "CUP_SMAW_HEDP_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Mk153Mod0_blk", 50, 1, 3, ["CUP_SMAW_HEAA_M", "CUP_SMAW_HEDP_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M136", 50, 3, 6, ["CUP_M136_M"], 1];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Javelin", 25, 1, 2, ["CUP_Javelin_M"], 2];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_FIM92Stinger", 50, 1, 2, ["CUP_Stinger_M"], 0];
+// non-CSAT weapons
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_MAAWS", 50, 1, 2, ["CUP_MAAWS_HEAT_M", "CUP_MAAWS_HEDP_M", "MRAWS_HEAT_F", "MRAWS_HE_F"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M47", 10, 1, 2, ["CUP_Dragon_EP1_M"], 2];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M72A6", 50, 1, 6, [], 0];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M72A6_Special", 10, 1, 1, [], 0];
+
+
+// Weapons and ammo in the ordnance box
+a3e_arr_AmmoDepotOrdnance = [];
+// General weapons
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["CUP_TimeBomb_M", "CUP_PipeBomb_M"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["APERSMine_Range_Mag", "APERSBoundingMine_Range_Mag", "APERSTripMine_Wire_Mag"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "CUP_Mine_M"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["Laserbatteries"], 5];
+
+// Weapons and ammo in the vehicle box (the big one)
+// Some high volumes (mostly for immersion)
+a3e_arr_AmmoDepotVehicle = [];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_HandGrenade_M67"], 50];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["SmokeShell", "SmokeShellYellow", "SmokeShellRed", "SmokeShellGreen", "SmokeShellPurple", "SmokeShellBlue", "SmokeShellOrange"], 50];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow"], 50];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_Smoke_M203","CUP_1Rnd_SmokeRed_M203","CUP_1Rnd_SmokeGreen_M203","CUP_1Rnd_SmokeYellow_M203"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 25, 1, 1, ["CUP_1Rnd_StarCluster_White_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_1Rnd_StarCluster_Green_M203","CUP_1Rnd_StarFlare_White_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarFlare_Green_M203"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_FlareWhite_M203","CUP_FlareGreen_M203","CUP_FlareRed_M203","CUP_FlareYellow_M203"], 25];
+a3e_arr_AmmoDepotVehicleItems = [];
+a3e_arr_AmmoDepotVehicleItems pushback ["ToolKit", 20, 1, 1, [], 0];
+a3e_arr_AmmoDepotVehicleItems pushback ["Medikit", 20, 1, 1, [], 0];
+a3e_arr_AmmoDepotVehicleItems pushback ["FirstAidKit", 100, 10, 50, [], 0];
+a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_USMC_MOLLE_WDL"];
+
+// Items
+
+// Index 0: Item classname.
+// Index 1: Item's probability of presence (in percent, 0-100)..
+// Index 2: Minimum amount.
+// Index 3: Maximum amount.
+a3e_arr_AmmoDepotItems = [];
+a3e_arr_AmmoDepotItems pushback ["CUP_SOFLAM", 10, 1, 2];
+if(Param_NoNightvision==0) then {
+	a3e_arr_AmmoDepotItems pushback ["NVGoggles", 10, 1, 3];
+};
+a3e_arr_AmmoDepotItems pushback ["Binocular", 50, 2, 3, [], 0];
+a3e_arr_AmmoDepotItems pushback ["ItemCompass", 50, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["ItemGPS", 10, 1, 2];
+a3e_arr_AmmoDepotItems pushback ["ItemMap", 50, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["ItemRadio", 50, 1, 10];
+a3e_arr_AmmoDepotItems pushback ["ItemWatch", 50, 1, 10];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_ANPEQ_15_Black", 50, 1, 5];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_ANPEQ_15_OD", 50, 1, 5];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_ANPEQ_15_Flashlight_Black_L", 50, 1, 5];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_ANPEQ_15_Flashlight_OD_L", 50, 1, 5];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_Flashlight", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_Flashlight_wdl", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_mfsup_Flashhider_556x45_Black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_mfsup_Flashhider_556x45_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_snds_M16", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_snds_M16_camo", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM4", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_AIMM_COMPM4_BLK", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ElcanM145", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_SpecterDR_black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_SpecterDR_od", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_SpecterDR_RMR_black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_SpecterDR_RMR_od", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_reflex", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Elcan_reflex_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_HoloBlack", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_HoloWdl", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Eotech553_Black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Eotech553_Grey", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Eotech553_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_G33_HWS_BLK", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_G33_HWS_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_10x40_LRT_Woodland", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldM3LR", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_20x40_LRT", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_25x50_LRT", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_25x50_LRT_Woodland", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_CQ_T", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_Leupold_VX3", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_low", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_low_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_AIMM_M68_BLK", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_AIMM_M68_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_AIMM_COMPM2_BLK", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_AIMM_COMPM2_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_Black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_Woodland2", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_Woodland", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_SUSAT", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA01B_Black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA01B_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA01B_RMR_Black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA01B_RMR_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_RCO", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA01NSN_RMR_Black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA01NSN_RMR_OD", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG2", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA31_KF", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_TA31_KF_Wood", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ELCAN_SpecterDR", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_MRad", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_TrijiconRx01_black", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_SB_3_12x50_PMII", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_Reflex_Wood", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_TrijiconRx01_black", 10, 1, 3];
+if(Param_NoNightvision==0) then {
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PAS_13c1", 10, 1, 3];
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_10_black", 10, 1, 3];
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_10_od", 10, 1, 3];
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_4", 10, 1, 3];
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_M14", 10, 1, 3];
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_M16", 10, 1, 3];
+};
+a3e_arr_AmmoDepotItems pushback ["B_UavTerminal", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_bipod_VLTOR_Modpod_black", 20, 1, 2];
+a3e_arr_AmmoDepotItems pushback ["CUP_bipod_VLTOR_Modpod_OD", 20, 1, 2];
+a3e_arr_AmmoDepotItems pushback ["CUP_bipod_Harris_1A2_L", 20, 1, 2];
+
+
+// Weapons that may show up in civilian cars
+
+// Index 0: Weapon classname.
+// Index 1: Magazine classname.
+// Index 2: Number of magazines.
+a3e_arr_CivilianCarWeapons = [];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_PB6P9_snds", "CUP_8Rnd_9x18_MakarovSD_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL_railed", "CUP_20Rnd_762x51_FNFAL_M", 7];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Pellets", 11];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_HE", 9];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A2_Holo_Laser", "CUP_30Rnd_556x45_Stanag", 6];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_M14", "CUP_20Rnd_762x51_DMR", 8];
+a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_MicroUzi_snds", "CUP_30Rnd_9x19_UZI", 4];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_Saiga12K", "CUP_8Rnd_B_Saiga12_74Pellets_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_UK59", "CUP_50Rnd_UK59_762x54R_Tracer", 6];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AKS_Gold", "CUP_30Rnd_762x39_AK47_M", 8];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_ksvk_PSO3", "CUP_5Rnd_127x108_KSVK_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 1];
+a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_CZ584","CUP_1Rnd_B_CZ584_74Slug", 30];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_CZ584","CUP_1Rnd_B_CZ584_74Pellets", 30];
+//a3e_arr_CivilianCarWeapons pushback ["Medikit", objNull, 0];
+//a3e_arr_CivilianCarWeapons pushback ["Toolkit", objNull, 0];
+a3e_arr_CivilianCarWeapons pushback ["Binocular", objNull, 0];
+a3e_arr_CivilianCarWeapons pushback [objNull, "SatchelCharge_Remote_Mag", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "HandGrenade", 5];
+a3e_arr_CivilianCarWeapons pushback [objNull, "SmokeShell", 5];
+
+
+// Here is a list of scopes:
+a3e_arr_Scopes = [
+	"CUP_optic_HoloBlack"
+	,"CUP_optic_ACOG"
+	,"CUP_optic_CompM2_low"
+	,"CUP_optic_RCO"];
+a3e_arr_Scopes_SMG = [];
+a3e_arr_Scopes_Sniper = [
+	"CUP_optic_LeupoldMk4"
+	,"CUP_optic_LeupoldM3LR"
+	,"CUP_optic_LeupoldMk4_20x40_LRT"
+	,"CUP_optic_LeupoldMk4_25x50_LRT"];
+a3e_arr_NightScopes = [
+	"CUP_optic_AN_PVS_10_black"
+	,"CUP_optic_AN_PVS_4"
+	,"CUP_optic_AN_PVS_M14"
+	,"CUP_optic_AN_PVS_M16"];
+a3e_arr_TWSScopes = [
+     "CUP_optic_AN_PAS_13c1"];
+
+// Here is a list of bipods, might get randomly added to enemy patrols:
+a3e_arr_Bipods = [
+	"CUP_bipod_VLTOR_Modpod_black"
+	,"CUP_bipod_Harris_1A2_L"];
+
+
+//////////////////////////////////////////////////////////////////
+// RunExtraction.sqf
+// Helicopters that come to pick you up
+//////////////////////////////////////////////////////////////////
+a3e_arr_extraction_chopper = [
+	"CUP_O_Mi24_V_Dynamic_RU"
+	,"CUP_O_Mi8_RU"];
+a3e_arr_extraction_chopper_escort = [
+	"CUP_O_Mi24_V_Dynamic_RU"
+	,"CUP_O_Mi24_P_Dynamic_RU"
+	,"CUP_O_Ka50_DL_RU"
+	,"CUP_O_Ka52_RU"];
+
+//////////////////////////////////////////////////////////////////
+// EscapeSurprises.sqf and CreateSearchDrone.sqf
+// Classnames of drones
+//////////////////////////////////////////////////////////////////
+a3e_arr_searchdrone = [
+	"CUP_USMC_MQ9"];
+
+//////////////////////////////////////////////////////////////////
+// CreateSearchChopper.sqf
+// first chopper that's called when you escape
+// Two arrays for "Easy" and "Hard" parameter, both used on stadard setting
+//////////////////////////////////////////////////////////////////
+a3e_arr_searchChopperEasy = [
+	"CUP_B_UH1Y_UNA_USMC"];
+a3e_arr_searchChopperHard = [
+     "CUP_B_MH60L_DAP_2x_USN"
+	,"CUP_B_MH60L_DAP_4x_USN"
+    ,"CUP_B_MH60S_USMC"
+	,"CUP_B_UH60S_USN"
+	,"CUP_B_UH1Y_Gunship_Dynamic_USMC"];
+a3e_arr_searchChopper_pilot = [
+	"CUP_B_USMC_Pilot"];
+a3e_arr_searchChopper_crew = [
+	"CUP_B_USMC_Pilot"];
+
+if(Param_SearchChopper==0) then {
+	a3e_arr_searchChopper = a3e_arr_searchChopperEasy + a3e_arr_searchChopperHard;
+};
+if(Param_SearchChopper==1) then {
+	a3e_arr_searchChopper = a3e_arr_searchChopperEasy;
+};
+if(Param_SearchChopper==2) then {
+	a3e_arr_searchChopper = a3e_arr_searchChopperHard;
+};
+
+//////////////////////////////////////////////////////////////////
+// fn_AmbientInfantry
+// only INS is used
+//is this even used?
+//////////////////////////////////////////////////////////////////
+a3e_arr_AmbientInfantry_Inf_INS = a3e_arr_Escape_InfantryTypes;
+a3e_arr_AmbientInfantry_Inf_GUE = a3e_arr_Escape_InfantryTypes_Ind;
+
+//////////////////////////////////////////////////////////////////
+// fn_InitGuardedLocations
+// Units spawned to guard ammo camps and com centers
+// Only INS used
+//////////////////////////////////////////////////////////////////
+a3e_arr_InitGuardedLocations_Inf_INS = a3e_arr_Escape_InfantryTypes;
+a3e_arr_InitGuardedLocations_Inf_GUE = a3e_arr_Escape_InfantryTypes_Ind;
+
+//////////////////////////////////////////////////////////////////
+// fn_roadblocks
+// units spawned on roadblocks
+// Only INS used
+// vehicle arrays not used, uses a3e_arr_Escape_RoadBlock_MannedVehicleTypes and a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind instead
+//////////////////////////////////////////////////////////////////
+a3e_arr_roadblocks_Inf_INS = a3e_arr_Escape_InfantryTypes;
+a3e_arr_roadblocks_Inf_GUE = a3e_arr_Escape_InfantryTypes_Ind;
+
+a3e_arr_roadblocks_Veh_INS = a3e_arr_Escape_RoadBlock_MannedVehicleTypes;
+a3e_arr_roadblocks_Veh_GUE = a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind;
+
+//////////////////////////////////////////////////////////////////
+// fn_PopulateAquaticPatrol
+// boats that are spawned
+//////////////////////////////////////////////////////////////////
+a3e_arr_AquaticPatrols = [
+	"CUP_B_RHIB_USMC"
+	,"CUP_B_RHIB2Turret_USMC"];
+
+//////////////////////////////////////////////////////////////////
+// fn_AmmoDepot
+// What kind of weapon boxes are spawned when the parameter "additional weapons" is activated
+// use to add boxes from mods to the ammo depots
+//////////////////////////////////////////////////////////////////
+a3e_additional_weapon_box_1 = "CUP_USBasicWeaponsBox";
+a3e_additional_weapon_box_2 = "CUP_USSpecialWeaponsBox";
+
+//////////////////////////////////////////////////////////////////
+// fn_MortarSite
+// mortar spawned in the mortar camps
+//////////////////////////////////////////////////////////////////
+a3e_arr_MortarSite = [
+	"CUP_B_M252_USMC"];
+
+//////////////////////////////////////////////////////////////////
+// fn_CallCAS.sqf
+// Classnames of planes for the CAS module
+//////////////////////////////////////////////////////////////////
+a3e_arr_CASplane = [
+	"CUP_B_AV8B_DYN_USMC"
+	,"CUP_B_F35B_CAS_USMC"];
+
+//////////////////////////////////////////////////////////////////
+// fn_CrashSite
+// Random crashsite of west heli with west weapons
+//////////////////////////////////////////////////////////////////
+// The following arrays define weapons and ammo contained at crash sites
+// Index 0: Weapon classname.
+// Index 1: Weapon's probability of presence (in percent, 0-100).
+// Index 2: If weapon exists, crate contains at minimum this number of weapons of current class.
+// Index 3: If weapon exists, crate contains at maximum this number of weapons of current class.
+// Index 4: Array of magazine classnames. Magazines of these types are present if weapon exists.
+// Index 5: Number of magazines per weapon that exists.
+a3e_arr_CrashSiteWrecks = [
+	"Mi8Wreck"];
+a3e_arr_CrashSiteCrew = [
+	"CUP_O_RU_Pilot"];
+a3e_arr_CrashSiteWrecksCar = [
+	"Land_Wreck_BMP2_F"
+	,"Land_Wreck_BRDM2_F"
+	,"T72Wreck"
+	,"BDRMWreck"];
+a3e_arr_CrashSiteCrewCar = [
+	"CUP_O_RU_Crew"];
+// Weapons and ammo in crash site box
+a3e_arr_CrashSiteWeapons = [];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74M_GL", 50, 2, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M","CUP_1Rnd_HE_GP25_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74M", 50, 2, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG7V", 10, 1, 2, ["CUP_PG7V_M"], 2];
+a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_Pecheneg", 10, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 5];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AKS74U", 75, 2, 4, ["CUP_30Rnd_545x39_AK74_plum_M"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_SVD", 20, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_VSSVintorez", 10, 1, 2, ["CUP_20Rnd_9x39_SP5_VSS_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_RPK74M", 10, 1, 2, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK74M_M"], 6];
+// Attachments and other items in crash site box
+a3e_arr_CrashSiteItems = [];
+a3e_arr_CrashSiteItems pushback ["CUP_muzzle_PBS4", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_muzzle_Bizon", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_Kobra", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_Kobra", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_1p63", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_ekp_8_02", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_3", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PechenegScope", 10, 1, 3];

--- a/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
@@ -48,6 +48,7 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9_snds","CUP_15Rnd_9x19_M9"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17_blk","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_flashlight_snds","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_snds","CUP_17Rnd_9x19_glock17"];
@@ -77,13 +78,7 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455_gold","CUP_6R
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
@@ -92,37 +87,12 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5_flashlight","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5SD6","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5_flashlight","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5SD6","CUP_30Rnd_9x19_MP5"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Beneli_74Pellets"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Benelli_74Slug"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Beneli_74Pellets"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Benelli_74Slug"];
+
+
 
 
 // Random array. Civilian vehicle classes for ambient traffic.

--- a/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
@@ -48,7 +48,6 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9_snds","CUP_15Rnd_9x19_M9"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17_blk","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_flashlight_snds","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_snds","CUP_17Rnd_9x19_glock17"];
@@ -78,7 +77,13 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455_gold","CUP_6R
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
@@ -87,12 +92,37 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-
-
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5_flashlight","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5SD6","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5A5_flashlight","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_MP5SD6","CUP_30Rnd_9x19_MP5"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Beneli_74Pellets"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Benelli_74Slug"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Beneli_74Pellets"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_sgun_M1014_Entry","CUP_6Rnd_B_Benelli_74Slug"];
 
 
 // Random array. Civilian vehicle classes for ambient traffic.


### PR DESCRIPTION
While the logistics of smuggling in a full size smg like the MP5 and shotguns such as the short barrelled version of the M1014 may seem a bit outrageous I think it helps compensate for the armor of the new RACS units.  The shotguns are mostly a fun surprise and the very long reload time and low magazine capacity helps balance them.  I don't think the 50/50 pistol to smg ratio or 50/45/5 pistol to smg to shotgun ratio is necessary for all versions, but for this version and other versions with heavy armor, such as vanilla, I've found it greatly improves the starting experience for small groups of 2-4 players. 

The prison escape should be challenging, but on some versions it can get tedious and demoralizing very quickly, and I think it can drive away players that otherwise would very much enjoy the mission.  The prison escape difficulty difference between this version and the Taki versions is pretty stark due to the armor of the prison guards, while the rest of the mission isn't particularly less or more difficult when comparing those two versions, for example, so the added weapons will help smooth out the initial difficulty spike. 

I'm open to suggestions, but I think variety is escapes best feature and it's somewhat of a showcase of so much of the content from the base game and mods, so I personally think trying to add as much content as possible, within reason (no vanilla units in CUP versions for example) should be the goal.