### PR TITLE
Fix "Picture mapconfig\logo.paa not found" error

### DIFF
--- a/Code/functions/Templates/fn_AmmoDepot2.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot2.sqf
@@ -152,7 +152,7 @@ _obj = "Flag_CSAT_F" createvehicle _pos;
 _obj setVectorDirAndUp [[0.0760487,-0.997104,0],[0,-0,1]];
 _obj setdir ((getdir _obj) + _rotation);
 _obj setPosATL _pos;
-_obj forceFlagTexture "mapConfig\logo.paa"; 
+//_obj forceFlagTexture "mapConfig\logo.paa"; 
 
 _pos = [_center,_center vectorAdd [4.15967,-5.37695,0],_rotation] call A3E_fnc_rotatePosition;
 _obj = "Land_Cargo_House_V2_F" createvehicle _pos;


### PR DESCRIPTION
Seems like it was an experimental change on some of the base templates that was commented out on all of them except one.

![ArmA 3 Screenshot 2019 11 04 - 23 16 34 22](https://user-images.githubusercontent.com/53233871/70069580-d88b8c80-15a6-11ea-8cf2-1ec6a4602121.png)
