### PR TITLE
Unit Config reworks

### DIFF
--- a/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
@@ -11,9 +11,9 @@ _enemyFrequency = _this select 0;
 
 //Sides
 
-A3E_VAR_Side_Blufor = east;//Player side CUP SLA
+A3E_VAR_Side_Blufor = east;//Player side CUP RU MSV - EMR
 A3E_VAR_Side_Opfor = west;//Enemy side CUP USMC woodland
-A3E_VAR_Side_Ind = resistance;//Independent side CUP RACS
+A3E_VAR_Side_Ind = resistance;//Independent side CUP RACS woodland
 
 A3E_VAR_Flag_Opfor = "\A3\Data_F\Flags\Flag_us_CO.paa";
 A3E_VAR_Flag_Ind = "\A3\Data_F\Flags\Flag_green_CO.paa";
@@ -31,6 +31,7 @@ a3e_arr_Escape_StartPositionGuardTypes = [
 
 // Prison backpack secondary weapon (and corresponding magazine type).
 a3e_arr_PrisonBackpackWeapons = [];
+//Pistols
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
@@ -79,6 +80,7 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+//SMGs
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
@@ -91,7 +93,6 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-
 
 
 
@@ -99,8 +100,20 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19
 a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 	"CUP_C_Datsun"
 	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
 	,"CUP_C_Datsun_4seat"
 	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
 	,"CUP_C_Golf4_random_Civ"
 	,"CUP_C_Golf4_random_Civ"
 	,"CUP_C_Golf4_random_Civ"
@@ -127,6 +140,47 @@ a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 	,"CUP_C_Octavia_CIV"
 	,"CUP_C_Octavia_CIV"
 	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
 	,"CUP_C_Skoda_Blue_CIV"
 	,"CUP_C_Skoda_Green_CIV"
 	,"CUP_C_Skoda_Red_CIV"
@@ -137,85 +191,139 @@ a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 	,"CUP_C_Skoda_White_CIV"
 	,"CUP_C_S1203_Militia_CIV"
 	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
 	,"CUP_C_Datsun_Covered"
 	,"CUP_C_Datsun_Covered"
 	,"CUP_C_Datsun_Plain"
 	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
 	,"CUP_C_Datsun_Tubeframe"
 	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
 	,"CUP_C_Lada_White_CIV"
 	,"CUP_C_Lada_White_CIV"
 	,"CUP_C_Lada_White_CIV"
 	,"CUP_LADA_LM_CIV"
 	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_SUV_CIV"
 	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
 	,"CUP_C_Tractor_CIV"
 	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_Old_CIV"
-	,"CUP_C_Tractor_Old_CIV"
 	,"CUP_C_Tractor_Old_CIV"
 	,"CUP_C_Tractor_Old_CIV"
 	,"CUP_C_Ural_Civ_03"
 	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
 	,"CUP_C_Ural_Open_Civ_03"
 	,"CUP_C_Ural_Open_Civ_03"
-	,"CUP_C_TT650_RU"
-	,"CUP_C_TT650_RU"
-	,"CUP_C_TT650_RU"
+	,"CUP_C_Ural_Open_Civ_03"
     ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
 	,"CUP_C_Ural_Open_Civ_01"
 	,"CUP_C_Ural_Civ_02"
 	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
 	,"CUP_C_Ural_Open_Civ_02"
 	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_TT650_TK"
-	,"CUP_C_TT650_TK"
-	,"CUP_C_TT650_TK"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
 	,"CUP_C_S1203_CIV"
 	,"CUP_C_S1203_CIV"
 	,"CUP_C_S1203_CIV"
 	,"CUP_C_Lada_GreenTK_CIV"
 	,"CUP_C_Lada_GreenTK_CIV"
 	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_V3S_Open_TKC"
 	,"CUP_C_V3S_Open_TKC"
 	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_SUV_TK"
 	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
 	,"CUP_C_UAZ_Unarmed_TK_CIV"
 	,"CUP_C_UAZ_Unarmed_TK_CIV"
 	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_Ural_Civ_01"
 	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
 	,"CUP_C_Volha_Blue_TKCIV"
 	,"CUP_C_Volha_Blue_TKCIV"
 	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Limo_TKCIV"
 	,"CUP_C_Volha_Limo_TKCIV"];
+	if(Param_UseDLCApex==1) then {
+	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Offroad_02_unarmed_F";
+	};
+	if(Param_UseDLCLaws==1) then {
+	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_medevac_F";
+	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_vehicle_F";
+	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_service_F";
+	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_transport_F";
+	};
 
 // Random arrays. Enemy vehicle classes for ambient traffic.
 // Variable _enemyFrequency applies to server parameter, and can be one of the values 1 (Few), 2 (Some) or 3 (A lot).
@@ -408,7 +516,7 @@ switch (_enemyFrequency) do {
 		,"CUP_B_LAV25_HQ_USMC"
 		,"CUP_B_LAV25_HQ_USMC"
 		,"CUP_B_LAV25_HQ_USMC"
-		//Armed APCs or AA  1 set  
+		//Heavily Armed APCs or AA  1 set  
 		,"CUP_B_AAV_USMC"
 		,"CUP_B_LAV25_USMC"
 		,"CUP_B_LAV25M240_USMC"
@@ -785,10 +893,22 @@ a3e_arr_ComCenParkedVehicles = [
 
 // Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
 a3e_arr_Escape_EnemyCivilianCarTypes = [
-    "CUP_C_Datsun"
+	"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
 	,"CUP_C_Datsun"
 	,"CUP_C_Datsun_4seat"
 	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
 	,"CUP_C_Golf4_random_Civ"
 	,"CUP_C_Golf4_random_Civ"
 	,"CUP_C_Golf4_random_Civ"
@@ -815,6 +935,43 @@ a3e_arr_Escape_EnemyCivilianCarTypes = [
 	,"CUP_C_Octavia_CIV"
 	,"CUP_C_Octavia_CIV"
 	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
 	,"CUP_C_Skoda_Blue_CIV"
 	,"CUP_C_Skoda_Green_CIV"
 	,"CUP_C_Skoda_Red_CIV"
@@ -825,85 +982,131 @@ a3e_arr_Escape_EnemyCivilianCarTypes = [
 	,"CUP_C_Skoda_White_CIV"
 	,"CUP_C_S1203_Militia_CIV"
 	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
 	,"CUP_C_Datsun_Covered"
 	,"CUP_C_Datsun_Covered"
 	,"CUP_C_Datsun_Plain"
 	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
 	,"CUP_C_Datsun_Tubeframe"
 	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
 	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
 	,"CUP_C_Lada_White_CIV"
 	,"CUP_C_Lada_White_CIV"
 	,"CUP_C_Lada_White_CIV"
 	,"CUP_LADA_LM_CIV"
 	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_SUV_CIV"
 	,"CUP_C_SUV_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_Old_CIV"
-	,"CUP_C_Tractor_Old_CIV"
-	,"CUP_C_Tractor_Old_CIV"
-	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Ural_Civ_03"
 	,"CUP_C_Ural_Civ_03"
 	,"CUP_C_Ural_Civ_03"
 	,"CUP_C_Ural_Open_Civ_03"
 	,"CUP_C_Ural_Open_Civ_03"
-	,"CUP_C_TT650_RU"
-	,"CUP_C_TT650_RU"
-	,"CUP_C_TT650_RU"
+	,"CUP_C_Ural_Open_Civ_03"
     ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
 	,"CUP_C_Ural_Open_Civ_01"
 	,"CUP_C_Ural_Civ_02"
 	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
 	,"CUP_C_Ural_Open_Civ_02"
 	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_TT650_TK"
-	,"CUP_C_TT650_TK"
-	,"CUP_C_TT650_TK"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
 	,"CUP_C_S1203_CIV"
 	,"CUP_C_S1203_CIV"
 	,"CUP_C_S1203_CIV"
 	,"CUP_C_Lada_GreenTK_CIV"
 	,"CUP_C_Lada_GreenTK_CIV"
 	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_LR_Transport_CTK"
 	,"CUP_C_V3S_Open_TKC"
 	,"CUP_C_V3S_Open_TKC"
 	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_V3S_Covered_TKC"
 	,"CUP_C_SUV_TK"
 	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
 	,"CUP_C_UAZ_Unarmed_TK_CIV"
 	,"CUP_C_UAZ_Unarmed_TK_CIV"
 	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_UAZ_Open_TK_CIV"
 	,"CUP_C_Ural_Civ_01"
 	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
 	,"CUP_C_Volha_Blue_TKCIV"
 	,"CUP_C_Volha_Blue_TKCIV"
 	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Gray_TKCIV"
 	,"CUP_C_Volha_Limo_TKCIV"
 	,"CUP_C_Volha_Limo_TKCIV"];
+	if(Param_UseDLCApex==1) then {
+		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
+	};
+	if(Param_UseDLCLaws==1) then {
+	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_medevac_F";
+	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_vehicle_F";
+	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_service_F";
+	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_transport_F";
+	};
 
 
 // Vehicles, weapons and ammo at ammo depots
@@ -1013,7 +1216,7 @@ a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_FIM92Stinger", 50, 1, 2, ["CUP_
 // non-CSAT weapons
 a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_MAAWS", 50, 1, 2, ["CUP_MAAWS_HEAT_M", "CUP_MAAWS_HEDP_M", "MRAWS_HEAT_F", "MRAWS_HE_F"], 3];
 a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M47", 10, 1, 2, ["CUP_Dragon_EP1_M"], 2];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M72A6", 50, 1, 6, [], 0];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M72A6", 50, 3, 6, [], 0];
 a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M72A6_Special", 10, 1, 1, [], 0];
 
 
@@ -1032,8 +1235,7 @@ a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_HandGrenade_M67"], 5
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["SmokeShell", "SmokeShellYellow", "SmokeShellRed", "SmokeShellGreen", "SmokeShellPurple", "SmokeShellBlue", "SmokeShellOrange"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_Smoke_M203","CUP_1Rnd_SmokeRed_M203","CUP_1Rnd_SmokeGreen_M203","CUP_1Rnd_SmokeYellow_M203"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 25, 1, 1, ["CUP_1Rnd_StarCluster_White_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_1Rnd_StarCluster_Green_M203","CUP_1Rnd_StarFlare_White_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarFlare_Green_M203"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_FlareWhite_M203","CUP_FlareGreen_M203","CUP_FlareRed_M203","CUP_FlareYellow_M203"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 100, 1, 1, ["CUP_1Rnd_StarCluster_White_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_1Rnd_StarCluster_Green_M203","CUP_1Rnd_StarFlare_White_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarFlare_Green_M203"], 25];
 a3e_arr_AmmoDepotVehicleItems = [];
 a3e_arr_AmmoDepotVehicleItems pushback ["ToolKit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["Medikit", 20, 1, 1, [], 0];
@@ -1123,13 +1325,13 @@ a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG_Reflex_Wood", 10, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["CUP_optic_TrijiconRx01_black", 10, 1, 3];
 if(Param_NoNightvision==0) then {
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PAS_13c1", 10, 1, 3];
+	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PAS_13c2", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_10_black", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_10_od", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_4", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_M14", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_M16", 10, 1, 3];
 };
-a3e_arr_AmmoDepotItems pushback ["B_UavTerminal", 10, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["CUP_bipod_VLTOR_Modpod_black", 20, 1, 2];
 a3e_arr_AmmoDepotItems pushback ["CUP_bipod_VLTOR_Modpod_OD", 20, 1, 2];
 a3e_arr_AmmoDepotItems pushback ["CUP_bipod_Harris_1A2_L", 20, 1, 2];
@@ -1145,19 +1347,15 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_PB6P9_snds", "CUP_8Rnd_9x18_MakarovSD_M", 5];
 a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL_railed", "CUP_20Rnd_762x51_FNFAL_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Pellets", 11];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_HE", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A2_Holo_Laser", "CUP_30Rnd_556x45_Stanag", 6];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Slug", 9];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_M14", "CUP_20Rnd_762x51_DMR", 8];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_MicroUzi_snds", "CUP_30Rnd_9x19_UZI", 4];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_Saiga12K", "CUP_8Rnd_B_Saiga12_74Pellets_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_UK59", "CUP_50Rnd_UK59_762x54R_Tracer", 6];
 a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AKS_Gold", "CUP_30Rnd_762x39_AK47_M", 8];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_ksvk_PSO3", "CUP_5Rnd_127x108_KSVK_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 1];
 a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_CZ584","CUP_1Rnd_B_CZ584_74Slug", 30];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_CZ584","CUP_1Rnd_B_CZ584_74Pellets", 30];
 //a3e_arr_CivilianCarWeapons pushback ["Medikit", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Toolkit", objNull, 0];
 a3e_arr_CivilianCarWeapons pushback ["Binocular", objNull, 0];
@@ -1313,32 +1511,34 @@ a3e_arr_CASplane = [
 a3e_arr_CrashSiteWrecks = [
 	"Mi8Wreck"];
 a3e_arr_CrashSiteCrew = [
-	"CUP_O_RU_Pilot"];
+	"CUP_O_RU_Pilot_EMR"];
 a3e_arr_CrashSiteWrecksCar = [
 	"Land_Wreck_BMP2_F"
 	,"Land_Wreck_BRDM2_F"
 	,"T72Wreck"
 	,"BDRMWreck"];
 a3e_arr_CrashSiteCrewCar = [
-	"CUP_O_RU_Crew"];
+	"CUP_O_RU_Crew_EMR"];
 // Weapons and ammo in crash site box
 a3e_arr_CrashSiteWeapons = [];
+a3e_arr_CrashSiteWeapons pushback ["CUP_hgun_PB6P9", 50, 2, 5, ["CUP_8Rnd_9x18_Makarov_M", "CUP_8Rnd_9x18_MakarovSD_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74m", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
 a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74M_GL", 50, 2, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M","CUP_1Rnd_HE_GP25_M"], 4];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74M", 50, 2, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AKS74U", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
 a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG7V", 10, 1, 2, ["CUP_PG7V_M"], 2];
-a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_Pecheneg", 10, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 5];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AKS74U", 75, 2, 4, ["CUP_30Rnd_545x39_AK74_plum_M"], 6];
-a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_SVD", 20, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 8];
-a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_VSSVintorez", 10, 1, 2, ["CUP_20Rnd_9x39_SP5_VSS_M"], 8];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_RPK74M", 10, 1, 2, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK74M_M"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG7V", 10, 1, 2, ["CUP_PG7V_M", "CUP_PG7VM_M", "CUP_PG7VL_M", "CUP_PG7VR_M", "CUP_OG7_M", "CUP_TBG7V_M"], 2];
+a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG18", 10, 2, 4, ["CUP_RPG18_M"], 0];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_RPK74_45", 25, 1, 2, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M"], 5];
+a3e_arr_CrashSiteWeapons pushback ["CUP_SVD", 25, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_VSSVintorez_pso", 10, 1, 2, ["CUP_20Rnd_9x39_SP5_VSS_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_smg_bizon", 10, 1, 2, ["CUP_64Rnd_9x19_Bizon_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_Pecheneg", 25, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_sgun_Saiga12K", 10, 1, 2, ["CUP_8Rnd_B_Saiga12_74Pellets_M", "CUP_8Rnd_B_Saiga12_74Slug_M"], 6];
 // Attachments and other items in crash site box
 a3e_arr_CrashSiteItems = [];
 a3e_arr_CrashSiteItems pushback ["CUP_muzzle_PBS4", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["CUP_muzzle_Bizon", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["CUP_optic_Kobra", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_Kobra", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_1p63", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_ekp_8_02", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_3", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_PechenegScope", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1_AK", 50, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1", 50, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PechenegScope", 25, 1, 3];

--- a/Mods/CUP Taki/UnitClasses.sqf
+++ b/Mods/CUP Taki/UnitClasses.sqf
@@ -22,235 +22,802 @@ A3E_VAR_Side_Ind_Str = format["%1",A3E_VAR_Side_Ind];
 
 // Random array. Start position guard types around the prison.
 a3e_arr_Escape_StartPositionGuardTypes = [
-	"CUP_O_TK_INS_Soldier"
-	,"CUP_O_TK_INS_Soldier"
-	,"CUP_O_TK_INS_Soldier_GL"
-	,"CUP_O_TK_INS_Soldier_Enfield"
-	,"CUP_O_TK_INS_Soldier_FNFAL"
-	,"CUP_O_TK_INS_Soldier_AR"];
+	"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier_GL"
+	,"CUP_I_TK_GUE_Guerilla_Enfield" 
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Soldier_AR"];
 
 // Prison backpack secondary weapon (and corresponding magazine type).
 a3e_arr_PrisonBackpackWeapons = [];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911_snds","CUP_7Rnd_45ACP_1911"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Compact","CUP_10Rnd_9x19_Compact"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Duty","16Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Duty_M3X","16Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_flashlight","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_snds","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_flashlight_snds","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9_snds","CUP_15Rnd_9x19_M9"];
+//Pistols
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9_snds","CUP_8Rnd_9x18_MakarovSD_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Phantom","CUP_18Rnd_9x19_Phantom"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Phantom_Flashlight","CUP_18Rnd_9x19_Phantom"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Phantom_Flashlight_snds","CUP_18Rnd_9x19_Phantom"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9_snds","CUP_8Rnd_9x18_MakarovSD_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PMM","CUP_12Rnd_9x18_PMM_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PMM","CUP_12Rnd_9x18_PMM_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PMM","CUP_12Rnd_9x18_PMM_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PMM","CUP_12Rnd_9x18_PMM_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455_gold","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+//SMGs
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_SA61","CUP_20Rnd_B_765x17_Ball_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_SA61","CUP_20Rnd_B_765x17_Ball_M"];
 
 // Random array. Civilian vehicle classes for ambient traffic.
 a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
-	"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_03"
+	"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
 	,"CUP_C_Datsun"
 	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_camo_Civ"
+	,"CUP_C_Golf4_camodark_Civ"
+	,"CUP_C_Golf4_camodigital_Civ"
+	,"CUP_C_Golf4_crowe_Civ"
+	,"CUP_C_Golf4_kitty_Civ"
+	,"CUP_C_Golf4_reptile_Civ"
+	,"CUP_C_Golf4_whiteblood_Civ"
 	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
 	,"CUP_C_Skoda_Blue_CIV"
 	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Golf4_red_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_Lada_TK2_CIV"
+	,"CUP_Lada_TK2_CIV"
+	,"CUP_Lada_TK2_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_SUV_CIV"
-	,"C_Hatchback_01_F"
-	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
-	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
-	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
-	,"C_Truck_02_covered_F"
-	,"C_Offroad_01_repair_F"
-	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"];
-	if(Param_UseDLCApex==1) then {
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Offroad_02_unarmed_F";
-	};
-	if(Param_UseDLCLaws==1) then {
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_medevac_F";
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_vehicle_F";
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_service_F";
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_transport_F";
-	};
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+    ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_TK2_CIV"
+	,"CUP_C_Lada_TK2_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"];
 
 // Random arrays. Enemy vehicle classes for ambient traffic.
 // Variable _enemyFrequency applies to server parameter, and can be one of the values 1 (Few), 2 (Some) or 3 (A lot).
 switch (_enemyFrequency) do {
     case 1: {//Few (1-3)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"CUP_O_LR_Transport_TKA"
-		,"CUP_O_LR_MG_TKA"
+		//Unarmed Cars  3 sets
+		"CUP_O_TT650_TKA"  //1
 		,"CUP_O_LR_Ambulance_TKA"
-		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
 		,"CUP_O_UAZ_Unarmed_TKA"
 		,"CUP_O_UAZ_Open_TKA"
-		,"CUP_O_UAZ_MG_TKA"
-		,"CUP_O_UAZ_AGS30_TKA"
-		,"CUP_O_UAZ_SPG9_TKA"
 		,"CUP_O_Ural_TKA"
-		,"CUP_O_Ural_Open_TKA"
 		,"CUP_O_Ural_Empty_TKA"
-		,"CUP_O_Ural_ZU23_TKA"
-		,"CUP_O_BM21_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		,"CUP_O_TT650_TKA"  //2
+		,"CUP_O_LR_Ambulance_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
+		,"CUP_O_UAZ_Unarmed_TKA"
+		,"CUP_O_UAZ_Open_TKA"
+		,"CUP_O_Ural_TKA"
+		,"CUP_O_Ural_Empty_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		,"CUP_O_TT650_TKA"  //3
+		,"CUP_O_LR_Ambulance_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
+		,"CUP_O_UAZ_Unarmed_TKA"
+		,"CUP_O_UAZ_Open_TKA"
+		,"CUP_O_Ural_TKA"
+		,"CUP_O_Ural_Empty_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		//Easter Egg Unarmed Car  1 set
+		,"CUP_O_Tractor_Old_TKA"
+		//Supply Trucks  1 set
+		,"CUP_O_V3S_Rearm_TKA"
+		,"CUP_O_V3S_Refuel_TKA"
+		,"CUP_O_V3S_Repair_TKA"
+		,"CUP_O_Ural_Reammo_TKA"
 		,"CUP_O_Ural_Refuel_TKA"
 		,"CUP_O_Ural_Repair_TKA"
-		,"CUP_O_Ural_Reammo_TKA"
-		,"CUP_O_BTR60_TK"
-		,"CUP_O_BRDM2_TKA"
+		//Unarmed MRAPS  1 set
+		,"CUP_O_BTR40_TKA"
+		,"CUP_O_BTR40_TKA"
+		,"CUP_O_BTR40_TKA"
+		//Unarmed APCS  1 set
+		,"CUP_O_BMP2_AMB_TKA"
+		,"CUP_O_BMP2_AMB_TKA"
+		,"CUP_O_BMP2_AMB_TKA"
+		//Armed Cars  2 sets
+		,"CUP_O_LR_MG_TKA"  //1
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		,"CUP_O_LR_MG_TKA"  //2
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		//Light Armed APCs  2 sets
+		,"CUP_O_BMP_HQ_TKA"  //1
+		,"CUP_O_M113_Med_TKA"
+		,"CUP_O_BMP_HQ_TKA"  //2
+		,"CUP_O_M113_Med_TKA"
+		//MRAPs  2 sets
+		,"CUP_O_BRDM2_TKA"  //1
 		,"CUP_O_BRDM2_ATGM_TKA"
 		,"CUP_O_BRDM2_HQ_TKA"
+		,"CUP_O_BRDM2_TKA"  //2
+		,"CUP_O_BRDM2_ATGM_TKA"
+		,"CUP_O_BRDM2_HQ_TKA"
+		//Light AA  1 set
+		,"CUP_O_Ural_ZU23_TKA"
+		,"CUP_O_Ural_ZU23_TKA"
+		//Medium AA  1 set
+		,"CUP_O_BMP2_ZU_TKA"
+		,"CUP_O_BMP2_ZU_TKA"
+		//Heavily Armed APCs or AA 1 set
 		,"CUP_O_BMP1_TKA"
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
-		,"CUP_O_BMP_HQ_TKA"
-		,"CUP_O_BMP2_AMB_TKA"
-		,"CUP_O_BMP2_ZU_TKA"
-		,"CUP_O_ZSU23_TK"
+		,"CUP_O_BTR60_TK"
 		,"CUP_O_M113_TKA"
-		,"CUP_O_M113_Med_TKA"
+		,"CUP_O_MTLB_pk_TKA"
+		,"CUP_O_ZSU23_TK"
+		//Artillery
+		,"CUP_O_BM21_TKA"
+		//Tanks 1 set
 		,"CUP_O_T34_TKA"
 		,"CUP_O_T55_TK"
 		,"CUP_O_T72_TKA"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"CUP_O_LR_Transport_TKM"
-		,"CUP_O_LR_MG_TKM"
-		,"CUP_O_LR_SPG9_TKM"
-		,"CUP_O_Ural_ZU23_TKM"
-		,"CUP_I_Ural_ZU23_TK_Gue"
-		,"CUP_I_Datsun_PK_TK"
+		//Unarmed Cars  5 sets
+		"CUP_I_Datsun_4seat_TK"  //1
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //2
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //3
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //4
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //5
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		//Supply Trucks  3 sets
+		,"CUP_I_V3S_Rearm_TKG"  //1
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		,"CUP_I_V3S_Rearm_TKG"  //2
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		,"CUP_I_V3S_Rearm_TKG"  //3
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		//Unarmed MRAPS  1 set
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"	
+		//Armed Cars  1 set
 		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BRDM2_TK_Gue"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		//MRAPs  2 sets
+		,"CUP_I_BRDM2_TK_Gue"  //1
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_BRDM2_TK_Gue"  //2
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		// Light AA  1 set
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		//Heavily Armed APCs  1 set
 		,"CUP_I_BMP1_TK_GUE"
+        ,"CUP_I_BMP1_TK_GUE"
+        //Tanks 1 set
 		,"CUP_I_T34_TK_GUE"
 		,"CUP_I_T55_TK_GUE"];
     };
     case 2: {//Some (4-6)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"CUP_O_LR_Transport_TKA"
-		,"CUP_O_LR_MG_TKA"
+		//Unarmed Cars  3 sets
+		"CUP_O_TT650_TKA"  //1
 		,"CUP_O_LR_Ambulance_TKA"
-		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
 		,"CUP_O_UAZ_Unarmed_TKA"
 		,"CUP_O_UAZ_Open_TKA"
-		,"CUP_O_UAZ_MG_TKA"
-		,"CUP_O_UAZ_AGS30_TKA"
-		,"CUP_O_UAZ_SPG9_TKA"
 		,"CUP_O_Ural_TKA"
-		,"CUP_O_Ural_Open_TKA"
 		,"CUP_O_Ural_Empty_TKA"
-		,"CUP_O_Ural_ZU23_TKA"
-		,"CUP_O_BM21_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		,"CUP_O_TT650_TKA"  //2
+		,"CUP_O_LR_Ambulance_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
+		,"CUP_O_UAZ_Unarmed_TKA"
+		,"CUP_O_UAZ_Open_TKA"
+		,"CUP_O_Ural_TKA"
+		,"CUP_O_Ural_Empty_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		,"CUP_O_TT650_TKA"  //3
+		,"CUP_O_LR_Ambulance_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
+		,"CUP_O_UAZ_Unarmed_TKA"
+		,"CUP_O_UAZ_Open_TKA"
+		,"CUP_O_Ural_TKA"
+		,"CUP_O_Ural_Empty_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		//Easter Egg Unarmed Car  1 set
+		,"CUP_O_Tractor_Old_TKA"
+		//Supply Trucks  1 set
+		,"CUP_O_V3S_Rearm_TKA"
+		,"CUP_O_V3S_Refuel_TKA"
+		,"CUP_O_V3S_Repair_TKA"
+		,"CUP_O_Ural_Reammo_TKA"
 		,"CUP_O_Ural_Refuel_TKA"
 		,"CUP_O_Ural_Repair_TKA"
-		,"CUP_O_Ural_Reammo_TKA"
-		,"CUP_O_BTR60_TK"
-		,"CUP_O_BRDM2_TKA"
+		//Unarmed MRAPS  1 set
+		,"CUP_O_BTR40_TKA"
+		,"CUP_O_BTR40_TKA"
+		,"CUP_O_BTR40_TKA"
+		//Unarmed APCS  1 set
+		,"CUP_O_BMP2_AMB_TKA"
+		,"CUP_O_BMP2_AMB_TKA"
+		,"CUP_O_BMP2_AMB_TKA"
+		//Armed Cars  3 sets
+		,"CUP_O_LR_MG_TKA"  //1
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		,"CUP_O_LR_MG_TKA"  //2
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		,"CUP_O_LR_MG_TKA"  //3
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		//Light Armed APCs  2 sets
+		,"CUP_O_BMP_HQ_TKA"  //1
+		,"CUP_O_M113_Med_TKA"
+		,"CUP_O_BMP_HQ_TKA"  //2
+		,"CUP_O_M113_Med_TKA"
+		//MRAPs  3 sets
+		,"CUP_O_BRDM2_TKA"  //1
 		,"CUP_O_BRDM2_ATGM_TKA"
 		,"CUP_O_BRDM2_HQ_TKA"
+		,"CUP_O_BRDM2_TKA"  //2
+		,"CUP_O_BRDM2_ATGM_TKA"
+		,"CUP_O_BRDM2_HQ_TKA"
+		,"CUP_O_BRDM2_TKA"  //3
+		,"CUP_O_BRDM2_ATGM_TKA"
+		,"CUP_O_BRDM2_HQ_TKA"
+		//Light AA  1 set
+		,"CUP_O_Ural_ZU23_TKA"
+		,"CUP_O_Ural_ZU23_TKA"
+		//Medium AA  1 set
+		,"CUP_O_BMP2_ZU_TKA"
+		,"CUP_O_BMP2_ZU_TKA"
+		//Heavily Armed APCs or AA 1 set
 		,"CUP_O_BMP1_TKA"
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
-		,"CUP_O_BMP_HQ_TKA"
-		,"CUP_O_BMP2_AMB_TKA"
-		,"CUP_O_BMP2_ZU_TKA"
-		,"CUP_O_ZSU23_TK"
+		,"CUP_O_BTR60_TK"
 		,"CUP_O_M113_TKA"
-		,"CUP_O_M113_Med_TKA"
+		,"CUP_O_MTLB_pk_TKA"
+		,"CUP_O_ZSU23_TK"
+		//Artillery
+		,"CUP_O_BM21_TKA"
+		//Tanks 1 set
 		,"CUP_O_T34_TKA"
 		,"CUP_O_T55_TK"
 		,"CUP_O_T72_TKA"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"CUP_O_LR_Transport_TKM"
-		,"CUP_O_LR_MG_TKM"
-		,"CUP_O_LR_SPG9_TKM"
-		,"CUP_O_Ural_ZU23_TKM"
-		,"CUP_I_Ural_ZU23_TK_Gue"
-		,"CUP_I_Datsun_PK_TK"
+		//Unarmed Cars  5 sets
+		"CUP_I_Datsun_4seat_TK"  //1
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //2
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //3
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //4
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //5
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		//Supply Trucks  3 sets
+		,"CUP_I_V3S_Rearm_TKG"  //1
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		,"CUP_I_V3S_Rearm_TKG"  //2
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		,"CUP_I_V3S_Rearm_TKG"  //3
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		//Unarmed MRAPS  1 set
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		//Armed Cars  2 sets
+		,"CUP_I_Datsun_PK_TK_Random"  //1
 		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BRDM2_TK_Gue"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_Datsun_PK_TK_Random"  //2
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		//MRAPs  4 sets
+		,"CUP_I_BRDM2_TK_Gue"  //1
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_BRDM2_TK_Gue"  //2
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_BRDM2_TK_Gue"  //3
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_BRDM2_TK_Gue"  //4
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		// Light AA  2 sets
+		,"CUP_I_Ural_ZU23_TK_Gue"  //1
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Ural_ZU23_TK_Gue"  //2
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		//Heavily Armed APCs  1 set
 		,"CUP_I_BMP1_TK_GUE"
+        ,"CUP_I_BMP1_TK_GUE"
+        //Tanks 1 set
 		,"CUP_I_T34_TK_GUE"
 		,"CUP_I_T55_TK_GUE"];
     };
     default {//A lot (7-8)
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-        "CUP_O_LR_Transport_TKA"
-		,"CUP_O_LR_MG_TKA"
+		//Unarmed Cars  3 sets
+		"CUP_O_TT650_TKA"  //1
 		,"CUP_O_LR_Ambulance_TKA"
-		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
 		,"CUP_O_UAZ_Unarmed_TKA"
 		,"CUP_O_UAZ_Open_TKA"
-		,"CUP_O_UAZ_MG_TKA"
-		,"CUP_O_UAZ_AGS30_TKA"
-		,"CUP_O_UAZ_SPG9_TKA"
 		,"CUP_O_Ural_TKA"
-		,"CUP_O_Ural_Open_TKA"
 		,"CUP_O_Ural_Empty_TKA"
-		,"CUP_O_Ural_ZU23_TKA"
-		,"CUP_O_BM21_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		,"CUP_O_TT650_TKA"  //2
+		,"CUP_O_LR_Ambulance_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
+		,"CUP_O_UAZ_Unarmed_TKA"
+		,"CUP_O_UAZ_Open_TKA"
+		,"CUP_O_Ural_TKA"
+		,"CUP_O_Ural_Empty_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		,"CUP_O_TT650_TKA"  //3
+		,"CUP_O_LR_Ambulance_TKA"
+		,"CUP_O_LR_Transport_TKA"
+		,"CUP_O_V3S_Open_TKA"
+		,"CUP_O_V3S_Covered_TKA"
+		,"CUP_O_UAZ_Unarmed_TKA"
+		,"CUP_O_UAZ_Open_TKA"
+		,"CUP_O_Ural_TKA"
+		,"CUP_O_Ural_Empty_TKA"
+		,"CUP_O_Ural_Open_TKA"
+		//Easter Egg Unarmed Car  1 set
+		,"CUP_O_Tractor_Old_TKA"
+		//Supply Trucks  1 set
+		,"CUP_O_V3S_Rearm_TKA"
+		,"CUP_O_V3S_Refuel_TKA"
+		,"CUP_O_V3S_Repair_TKA"
+		,"CUP_O_Ural_Reammo_TKA"
 		,"CUP_O_Ural_Refuel_TKA"
 		,"CUP_O_Ural_Repair_TKA"
-		,"CUP_O_Ural_Reammo_TKA"
-		,"CUP_O_BTR60_TK"
-		,"CUP_O_BRDM2_TKA"
+		//Unarmed MRAPS  1 set
+		,"CUP_O_BTR40_TKA"
+		,"CUP_O_BTR40_TKA"
+		,"CUP_O_BTR40_TKA"
+		//Unarmed APCS  1 set
+		,"CUP_O_BMP2_AMB_TKA"
+		,"CUP_O_BMP2_AMB_TKA"
+		,"CUP_O_BMP2_AMB_TKA"
+		//Armed Cars  3 sets
+		,"CUP_O_LR_MG_TKA"  //1
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		,"CUP_O_LR_MG_TKA"  //2
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		,"CUP_O_LR_MG_TKA"  //3
+		,"CUP_O_LR_SPG9_TKA"
+		,"CUP_O_UAZ_AGS30_TKA"
+		,"CUP_O_UAZ_MG_TKA"
+		,"CUP_O_UAZ_METIS_TKA"
+		,"CUP_O_UAZ_SPG9_TKA"
+		,"CUP_O_BTR40_MG_TKA"
+		//Light Armed APCs  2 sets
+		,"CUP_O_BMP_HQ_TKA"  //1
+		,"CUP_O_M113_Med_TKA"
+		,"CUP_O_BMP_HQ_TKA"  //2
+		,"CUP_O_M113_Med_TKA"
+		//MRAPs  3 sets
+		,"CUP_O_BRDM2_TKA"  //1
 		,"CUP_O_BRDM2_ATGM_TKA"
 		,"CUP_O_BRDM2_HQ_TKA"
-		,"CUP_O_BMP1_TKA"
+		,"CUP_O_BRDM2_TKA"  //2
+		,"CUP_O_BRDM2_ATGM_TKA"
+		,"CUP_O_BRDM2_HQ_TKA"
+		,"CUP_O_BRDM2_TKA"  //3
+		,"CUP_O_BRDM2_ATGM_TKA"
+		,"CUP_O_BRDM2_HQ_TKA"
+		//Light AA  1 set
+		,"CUP_O_Ural_ZU23_TKA"
+		,"CUP_O_Ural_ZU23_TKA"
+		//Medium AA  1 set
+		,"CUP_O_BMP2_ZU_TKA"
+		,"CUP_O_BMP2_ZU_TKA"
+		//Heavily Armed APCs or AA 2 sets
+		,"CUP_O_BMP1_TKA"  //1
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
-		,"CUP_O_BMP_HQ_TKA"
-		,"CUP_O_BMP2_AMB_TKA"
-		,"CUP_O_BMP2_ZU_TKA"
-		,"CUP_O_ZSU23_TK"
+		,"CUP_O_BTR60_TK"
 		,"CUP_O_M113_TKA"
-		,"CUP_O_M113_Med_TKA"
+		,"CUP_O_MTLB_pk_TKA"
+		,"CUP_O_ZSU23_TK"
+		,"CUP_O_BMP1_TKA"  //2
+		,"CUP_O_BMP1P_TKA"
+		,"CUP_O_BMP2_TKA"
+		,"CUP_O_BTR60_TK"
+		,"CUP_O_M113_TKA"
+		,"CUP_O_MTLB_pk_TKA"
+		,"CUP_O_ZSU23_TK"
+		//Artillery
+		,"CUP_O_BM21_TKA"
+		//Tanks 2 sets
+		,"CUP_O_T34_TKA"
+		,"CUP_O_T55_TK"
+		,"CUP_O_T72_TKA"
 		,"CUP_O_T34_TKA"
 		,"CUP_O_T55_TK"
 		,"CUP_O_T72_TKA"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"CUP_O_LR_Transport_TKM"
-		,"CUP_O_LR_MG_TKM"
-		,"CUP_O_LR_SPG9_TKM"
-		,"CUP_O_Ural_ZU23_TKM"
-		,"CUP_I_Ural_ZU23_TK_Gue"
-		,"CUP_I_Datsun_PK_TK"
+		//Unarmed Cars  5 sets
+		"CUP_I_Datsun_4seat_TK"  //1
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //2
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //3
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //4
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_Datsun_4seat_TK"  //5
+		,"CUP_I_V3S_Open_TKG"
+		,"CUP_I_V3S_Covered_TKG"
+		//Supply Trucks  3 sets
+		,"CUP_I_V3S_Rearm_TKG"  //1
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		,"CUP_I_V3S_Rearm_TKG"  //2
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		,"CUP_I_V3S_Rearm_TKG"  //3
+		,"CUP_I_V3S_Refuel_TKG"
+		,"CUP_I_V3S_Repair_TKG"
+		//Unarmed MRAPS  1 set
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		,"CUP_I_BTR40_TKG"
+		//Armed Cars  2 sets
+		,"CUP_I_Datsun_PK_TK_Random"  //1
 		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BRDM2_TK_Gue"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_Datsun_PK_TK_Random"  //2
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		,"CUP_I_BTR40_MG_TKG"
+		//MRAPs  4 sets
+		,"CUP_I_BRDM2_TK_Gue"  //1
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
-		,"CUP_I_BMP1_TK_GUE"
-		,"CUP_I_T34_TK_GUE"
+		,"CUP_I_BRDM2_TK_Gue"  //2
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_BRDM2_TK_Gue"  //3
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_BRDM2_TK_Gue"  //4
+		,"CUP_I_BRDM2_ATGM_TK_Gue"
+		,"CUP_I_BRDM2_HQ_TK_Gue"
+		// Light AA  3 sets
+		,"CUP_I_Ural_ZU23_TK_Gue"  //1
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Ural_ZU23_TK_Gue"  //2
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Ural_ZU23_TK_Gue"  //3
+		,"CUP_I_Ural_ZU23_TK_Gue"
+		//Heavily Armed APCs  3 sets
+		,"CUP_I_BMP1_TK_GUE"  //1
+        ,"CUP_I_BMP1_TK_GUE"
+		,"CUP_I_BMP1_TK_GUE"  //2
+        ,"CUP_I_BMP1_TK_GUE"
+		,"CUP_I_BMP1_TK_GUE"  //3
+        ,"CUP_I_BMP1_TK_GUE"
+        //Tanks 2 sets
+		,"CUP_I_T34_TK_GUE"  //1
+		,"CUP_I_T55_TK_GUE"
+		,"CUP_I_T34_TK_GUE"  //2
 		,"CUP_I_T55_TK_GUE"];
     };
 };
@@ -258,43 +825,83 @@ switch (_enemyFrequency) do {
 // Random array. General infantry types. E.g. village patrols, ambient infantry, ammo depot guards, communication center guards, etc.
 a3e_arr_Escape_InfantryTypes = [
 	"CUP_O_TK_Soldier"
-	,"CUP_O_TK_Soldier_GL"
+	,"CUP_O_TK_Soldier"
+	,"CUP_O_TK_Soldier"
+	,"CUP_O_TK_Soldier"
+	,"CUP_O_TK_Soldier"
+	,"CUP_O_TK_Soldier"
+	,"CUP_O_TK_Soldier_Backpack"
+	,"CUP_O_TK_Soldier_Backpack"
+	,"CUP_O_TK_Soldier_Backpack"
 	,"CUP_O_TK_Soldier_Backpack"
 	,"CUP_O_TK_Soldier_AAT"
+	,"CUP_O_TK_Soldier_AAT"
+	,"CUP_O_TK_Soldier_AAT"
 	,"CUP_O_TK_Soldier_AMG"
+	,"CUP_O_TK_Soldier_AMG"
+	,"CUP_O_TK_Soldier_AMG"
+	,"CUP_O_TK_Soldier_GL"
+	,"CUP_O_TK_Soldier_GL"
 	,"CUP_O_TK_Soldier_LAT"
+	,"CUP_O_TK_Soldier_LAT"
+	,"CUP_O_TK_Soldier_LAT"
+	,"CUP_O_TK_Soldier_AT"
 	,"CUP_O_TK_Soldier_AT"
 	,"CUP_O_TK_Soldier_HAT"
 	,"CUP_O_TK_Soldier_AA"
 	,"CUP_O_TK_Engineer"
+	,"CUP_O_TK_Engineer"
+	,"CUP_O_TK_Soldier_MG"
 	,"CUP_O_TK_Soldier_MG"
 	,"CUP_O_TK_Soldier_AR"
+	,"CUP_O_TK_Soldier_AR"
 	,"CUP_O_TK_Medic"
+	,"CUP_O_TK_Medic"
+	,"CUP_O_TK_Soldier_SL"
 	,"CUP_O_TK_Soldier_SL"
 	,"CUP_O_TK_Officer"
 	,"CUP_O_TK_Spotter"
 	,"CUP_O_TK_Sniper"
 	,"CUP_O_TK_Sniper_KSVK"
-	,"CUP_O_TK_Sniper_SVD_Night"
-	,"CUP_O_TK_Soldier_AKS_Night"
-	,"CUP_O_TK_Soldier_FNFAL_Night"
-	,"CUP_O_TK_Soldier_AKS_74_GOSHAWK"];
+	,"CUP_O_TK_Commander"
+	,"CUP_O_TK_Soldier_M"
+	,"CUP_O_TK_Soldier_M"
+	,"CUP_O_TK_Soldier_M"];
 a3e_arr_Escape_InfantryTypes_Ind =  [
-	"CUP_O_TK_INS_Soldier"
-	,"CUP_O_TK_INS_Soldier_AAT"
-	,"CUP_O_TK_INS_Soldier_GL"
-	,"CUP_O_TK_INS_Soldier_Enfield"
-	,"CUP_O_TK_INS_Soldier_FNFAL"
-	,"CUP_O_TK_INS_Soldier_AA"
-	,"CUP_O_TK_INS_Soldier_AT"
-	,"CUP_O_TK_INS_Soldier_TL"
-	,"CUP_O_TK_INS_Sniper"
-	,"CUP_O_TK_INS_Soldier_AR"
-	,"CUP_O_TK_INS_Soldier_MG"
-	,"CUP_O_TK_INS_Guerilla_Medic"
-	,"CUP_O_TK_INS_Commander"
-	,"CUP_O_TK_INS_Mechanic"
-	,"CUP_O_TK_INS_Bomber"];
+	"CUP_I_TK_GUE_Soldier_AA"
+	,"CUP_I_TK_GUE_Soldier_AR"
+	,"CUP_I_TK_GUE_Soldier_AR"
+	,"CUP_I_TK_GUE_Guerilla_Medic"
+	,"CUP_I_TK_GUE_Guerilla_Medic"
+	,"CUP_I_TK_GUE_Demo"
+	,"CUP_I_TK_GUE_Demo"
+	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier_GL"
+	,"CUP_I_TK_GUE_Soldier_GL"
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Guerilla_Enfield"
+	,"CUP_I_TK_GUE_Guerilla_Enfield"
+	,"CUP_I_TK_GUE_Guerilla_Enfield"
+	,"CUP_I_TK_GUE_Soldier_AAT"
+	,"CUP_I_TK_GUE_Soldier_AAT"
+	,"CUP_I_TK_GUE_Soldier_LAT"
+	,"CUP_I_TK_GUE_Soldier_LAT"
+	,"CUP_I_TK_GUE_Soldier_AT"
+	,"CUP_I_TK_GUE_Soldier_AT"
+	,"CUP_I_TK_GUE_Sniper"
+	,"CUP_I_TK_GUE_Mechanic"
+	,"CUP_I_TK_GUE_Mechanic"
+	,"CUP_I_TK_GUE_Soldier_MG"
+	,"CUP_I_TK_GUE_Soldier_MG"
+	,"CUP_I_TK_GUE_Soldier_TL"
+	,"CUP_I_TK_GUE_Soldier_TL"
+	,"CUP_I_TK_GUE_Commander"];
 a3e_arr_recon_InfantryTypes = [
 	"CUP_O_TK_SpecOps"
 	,"CUP_O_TK_SpecOps"
@@ -303,74 +910,55 @@ a3e_arr_recon_InfantryTypes = [
 	,"CUP_O_TK_SpecOps_TL"
 	,"CUP_O_TK_SpecOps_MG"];
 a3e_arr_recon_I_InfantryTypes = [
-	"CUP_O_TK_INS_Soldier"
-	,"CUP_O_TK_INS_Soldier_AAT"
-	,"CUP_O_TK_INS_Soldier_GL"
-	,"CUP_O_TK_INS_Soldier_Enfield"
-	,"CUP_O_TK_INS_Soldier_FNFAL"
-	,"CUP_O_TK_INS_Soldier_AA"
-	,"CUP_O_TK_INS_Soldier_AT"
-	,"CUP_O_TK_INS_Soldier_TL"
-	,"CUP_O_TK_INS_Sniper"
-	,"CUP_O_TK_INS_Soldier_AR"
-	,"CUP_O_TK_INS_Soldier_MG"
-	,"CUP_O_TK_INS_Guerilla_Medic"
-	,"CUP_O_TK_INS_Commander"
-	,"CUP_O_TK_INS_Mechanic"
-	,"CUP_O_TK_INS_Bomber"];
+	"CUP_I_TK_GUE_Soldier_M16A2"
+	,"CUP_I_TK_GUE_Soldier_M16A2"
+	,"CUP_I_TK_GUE_Soldier_M16A2"
+	,"CUP_I_TK_GUE_Soldier_GL"];
 
 // Random array. A roadblock has a manned vehicle. This array contains possible manned vehicles (can be of any kind, like cars, armored and statics).
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
 	"CUP_O_LR_MG_TKA"
+	,"CUP_O_SPG9_TKA"
 	,"CUP_O_UAZ_MG_TKA"
 	,"CUP_O_UAZ_AGS30_TKA"
+	,"CUP_O_UAZ_MG_TKA"
+	,"CUP_O_UAZ_METIS_TKA"
 	,"CUP_O_UAZ_SPG9_TKA"
 	,"CUP_O_BTR60_TK"
 	,"CUP_O_BRDM2_TKA"
 	,"CUP_O_BRDM2_ATGM_TKA"
 	,"CUP_O_M113_TKA"
-	,"CUP_I_DSHkM_Mini_TriPod"
-	,"CUP_I_KORD_high_AAF"
-	,"CUP_I_AGS_AAF"
-	,"CUP_I_Metis_AAF"
-	,"CUP_I_SPG9_AAF"];
+	,"CUP_O_ZU23_TK"];
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind = [
-	"CUP_O_LR_MG_TKM"
-	,"CUP_O_LR_SPG9_TKM"
-	,"CUP_O_UAZ_SPG9_TKA"
+	"CUP_I_Datsun_PK_TK_Random"
 	,"CUP_I_Datsun_PK_TK_Random"
-	,"CUP_I_Datsun_PK_TK_Random"
-	,"CUP_I_DSHkM_Mini_TriPod"
-	,"CUP_I_KORD_high_AAF"
-	,"CUP_I_AGS_AAF"
-	,"CUP_I_Metis_AAF"
-	,"CUP_I_SPG9_AAF"];
+	,"CUP_I_BTR40_MG_TKG"
+	,"CUP_I_BRDM2_TK_Gue"
+	,"CUP_I_BRDM2_ATGM_TK_Gue"
+	,"CUP_I_ZU23_TK_GUE"];
 
 // Random array. Vehicle classes (preferrably trucks) transporting enemy reinforcements.
 a3e_arr_Escape_ReinforcementTruck_vehicleClasses = [
-	"CUP_O_UAZ_Unarmed_TKA"
-	,"CUP_O_LR_Transport_TKA"
+    "CUP_O_V3S_Open_TKA"
+	,"CUP_O_V3S_Covered_TKA"
 	,"CUP_O_Ural_TKA"
 	,"CUP_O_Ural_Open_TKA"];
 a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind = [
-	"CUP_O_UAZ_Unarmed_TKA"
-	,"CUP_O_Ural_TKA"
-	,"CUP_O_Ural_Open_TKA"
-	,"CUP_O_LR_Transport_TKM"];
+	"CUP_I_V3S_Open_TKG"
+	,"CUP_I_V3S_Covered_TKG"];
 
 
 
 
 // Random array. Motorized search groups are sometimes sent to look for you. This array contains possible class definitions for the vehicles.
 a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
-	"CUP_O_UAZ_Unarmed_TKA"
-	,"CUP_O_UAZ_Open_TKA"
-	,"CUP_O_LR_Transport_TKA"
-	,"CUP_O_LR_MG_TKA"
-	,"CUP_O_Ural_TKA"
+    "CUP_O_BMP1_TKA"
+	,"CUP_O_BMP1P_TKA"
+	,"CUP_O_BMP2_TKA"
+	,"CUP_O_BMP2_ZU_TKA"
 	,"CUP_O_BTR60_TK"
-	,"CUP_O_BRDM2_TKA"
-	,"CUP_O_M113_TKA"];
+	,"CUP_O_M113_TKA"
+	,"CUP_O_MTLB_pk_TKA"];
 
 
 
@@ -387,7 +975,6 @@ a3e_arr_ComCenDefence_lightArmorClasses = [
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"CUP_O_ZSU23_TK"
-	,"CUP_O_T55_TK"
 	,"CUP_O_T72_TKA"];
 
 // A communication center contains two static weapons (in two corners of the communication center).
@@ -396,99 +983,270 @@ a3e_arr_ComCenStaticWeapons = [
 	"CUP_O_KORD_high_TK"];
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
-	"I_G_Offroad_01_repair_F"
-	,"CUP_O_UAZ_Unarmed_TKA"
-	,"CUP_O_UAZ_Open_TKA"
-	,"CUP_O_UAZ_MG_TKA"
-	,"CUP_O_UAZ_SPG9_TKA"
-	,"CUP_O_LR_Transport_TKA"
-	,"CUP_O_LR_MG_TKA"
-	,"CUP_O_LR_Ambulance_TKA"
+    "CUP_O_Ural_ZU23_TKA"
+    ,"CUP_O_LR_Ambulance_TKA"
+    ,"CUP_O_LR_MG_TKA"
 	,"CUP_O_LR_SPG9_TKA"
+	,"CUP_O_LR_Transport_TKA"
+	,"CUP_O_UAZ_Unarmed_TKA"
+	,"CUP_O_V3S_Open_TKA"
+	,"CUP_O_V3S_Covered_TKA"
+	,"CUP_O_V3S_Rearm_TKA"
+	,"CUP_O_V3S_Refuel_TKA"
+	,"CUP_O_V3S_Repair_TKA"
+	,"CUP_O_UAZ_Unarmed_TKA"
+	,"CUP_O_UAZ_AGS30_TKA"
+	,"CUP_O_UAZ_MG_TKA"
+	,"CUP_O_UAZ_METIS_TKA"
+	,"CUP_O_UAZ_Open_TKA"
+	,"CUP_O_UAZ_SPG9_TKA"
 	,"CUP_O_Ural_TKA"
+	,"CUP_O_Ural_Reammo_TKA"
 	,"CUP_O_Ural_Open_TKA"
 	,"CUP_O_Ural_Refuel_TKA"
 	,"CUP_O_Ural_Repair_TKA"
-	,"CUP_O_Ural_Reammo_TKA"
-	,"CUP_O_Ural_ZU23_TKA"
-	,"I_G_Offroad_01_armed_F"];
+	,"CUP_O_Ural_ZU23_TKA"];
 
 // Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
 a3e_arr_Escape_EnemyCivilianCarTypes = [
-	"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_03"
+	"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
 	,"CUP_C_Datsun"
 	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_camo_Civ"
+	,"CUP_C_Golf4_camodark_Civ"
+	,"CUP_C_Golf4_camodigital_Civ"
+	,"CUP_C_Golf4_crowe_Civ"
+	,"CUP_C_Golf4_kitty_Civ"
+	,"CUP_C_Golf4_reptile_Civ"
+	,"CUP_C_Golf4_whiteblood_Civ"
 	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
 	,"CUP_C_Skoda_Blue_CIV"
 	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Golf4_red_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_S1203_Ambulance_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Ikarus_TKC"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_Lada_TK2_CIV"
+	,"CUP_Lada_TK2_CIV"
+	,"CUP_Lada_TK2_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_SUV_CIV"
-	,"C_Hatchback_01_F"
-	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
-	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
-	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
-	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"
-	,"C_Truck_02_covered_F"];
-	if(Param_UseDLCApex==1) then {
-		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
-	};
-	if(Param_UseDLCLaws==1) then {
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_medevac_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_vehicle_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_service_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_transport_F";
-	};
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+    ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"];
 
 // Vehicles, weapons and ammo at ammo depots
 
 // Random array. An ammo depot contains one static weapon of the followin types:
 a3e_arr_Escape_AmmoDepot_StaticWeaponClasses = [
-	"CUP_I_DSHKM_AAF"
-	,"CUP_I_DSHkM_Mini_TriPod"
-	,"CUP_I_KORD_AAF"
-	,"CUP_I_KORD_high_AAF"
-	,"CUP_I_AGS_AAF"
-	,"CUP_I_Metis_AAF"
-	,"CUP_I_SPG9_AAF"
-	,"CUP_I_Igla_AA_pod_AAF"];
+	"CUP_O_KORD_high_TK"
+	,"CUP_O_KORD_high_TK"
+	,"CUP_O_Igla_AA_pod_TK"];
 // An ammo depot have one parked and empty vehicle of the following possible types.
 a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
-	"I_G_Offroad_01_repair_F"
-	,"CUP_O_UAZ_Unarmed_TKA"
-	,"CUP_O_UAZ_Open_TKA"
-	,"CUP_O_UAZ_MG_TKA"
-	,"CUP_O_UAZ_SPG9_TKA"
-	,"CUP_O_LR_Transport_TKA"
-	,"CUP_O_LR_MG_TKA"
-	,"CUP_O_LR_Ambulance_TKA"
+    "CUP_O_Ural_ZU23_TKA"
+    ,"CUP_O_LR_Ambulance_TKA"
+    ,"CUP_O_LR_MG_TKA"
 	,"CUP_O_LR_SPG9_TKA"
+	,"CUP_O_LR_Transport_TKA"
+	,"CUP_O_UAZ_Unarmed_TKA"
+	,"CUP_O_V3S_Open_TKA"
+	,"CUP_O_V3S_Covered_TKA"
+	,"CUP_O_V3S_Rearm_TKA"
+	,"CUP_O_V3S_Refuel_TKA"
+	,"CUP_O_V3S_Repair_TKA"
+	,"CUP_O_UAZ_Unarmed_TKA"
+	,"CUP_O_UAZ_AGS30_TKA"
+	,"CUP_O_UAZ_MG_TKA"
+	,"CUP_O_UAZ_METIS_TKA"
+	,"CUP_O_UAZ_Open_TKA"
+	,"CUP_O_UAZ_SPG9_TKA"
 	,"CUP_O_Ural_TKA"
+	,"CUP_O_Ural_Reammo_TKA"
 	,"CUP_O_Ural_Open_TKA"
 	,"CUP_O_Ural_Refuel_TKA"
 	,"CUP_O_Ural_Repair_TKA"
-	,"CUP_O_Ural_Reammo_TKA"
-	,"CUP_O_Ural_ZU23_TKA"
-	,"I_G_Offroad_01_armed_F"];
+	,"CUP_O_Ural_ZU23_TKA"];
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
@@ -502,8 +1260,7 @@ a3e_arr_O_pilots = [
 a3e_arr_I_transport_heli = [
 	"CUP_I_UH1H_TK_GUE"];
 a3e_arr_I_pilots = [
-	"CUP_O_TK_Pilot"
-	,"CUP_O_TK_Pilot"];
+	"CUP_O_TK_GUE_Soldier"];
 
 
 // The following arrays define weapons and ammo contained at the ammo depots
@@ -517,52 +1274,50 @@ a3e_arr_I_pilots = [
 // Weapons and ammo in the basic weapons box
 a3e_arr_AmmoDepotBasicWeapons = [];
 // CSAT weapons
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_Makarov", 50, 2, 5, ["CUP_8Rnd_9x18_Makarov_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_Sa58P_des", 10, 1, 2, ["CUP_30Rnd_Sa58_M_TracerG"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74M", 50, 2, 4, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74M_GL", 75, 2, 4, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_1Rnd_HE_GP25_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_PKM", 20, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_SVD_des", 10, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_SVD_des_ghillie_pso", 10, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL", 100, 3, 5, ["CUP_20Rnd_762x51_FNFAL_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKS74U", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_White_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A2_GL", 75, 2, 4, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+
 // non-CSAT weapons
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_sgun_Saiga12K", 50, 2, 4, ["CUP_8Rnd_B_Saiga12_74Slug_M","CUP_8Rnd_B_Saiga12_74Pellets_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKM", 50, 1, 3, ["CUP_30Rnd_762x39_AK47_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74M_GL", 50, 1, 3, ["CUP_30Rnd_545x39_AK_M","CUP_1Rnd_HE_GP25_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_RPK74", 30, 1, 2, ["CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL5062", 10, 1, 2, ["CUP_20Rnd_762x51_FNFAL_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL", 10, 1, 2, ["CUP_20Rnd_762x51_FNFAL_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK107_GL_kobra", 10, 1, 2, ["CUP_30Rnd_545x39_AK_M", "CUP_1Rnd_HE_GP25_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_G36A_camo", 10, 1, 2, ["CUP_30Rnd_556x45_G36"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_G36C_camo", 10, 1, 2, ["CUP_30Rnd_556x45_G36"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_M14", 10, 1, 2, ["CUP_20Rnd_762x51_DMR"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_MG36_camo", 10, 1, 2, ["CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_smg_MP5A5", 10, 1, 2, ["CUP_30Rnd_9x19_MP5"], 8];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKM", 100, 3, 5, ["CUP_30Rnd_762x39_AK47_M", "CUP_30Rnd_762x39_AK47_TK_M", "CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Red_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Yellow_Tracer_762x39_AK47_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_LeeEnfield", 100, 3, 5, ["CUP_10x_303_M"], 15];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_White_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKM_GL", 75, 2, 4, ["CUP_30Rnd_762x39_AK47_M", "CUP_30Rnd_762x39_AK47_TK_M", "CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Red_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Yellow_Tracer_762x39_AK47_M", "CUP_1Rnd_HE_GP25_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A2_GL", 75, 2, 4, ["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Yellow","CUP_30Rnd_556x45_Stanag_Tracer_Green","CUP_30Rnd_556x45_Stanag_Tracer_Red","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKS", 75, 2, 4, ["CUP_30Rnd_762x39_AK47_M", "CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Red_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Yellow_Tracer_762x39_AK47_M"], 6];
+
+
+
 
 
 // Weapons and ammo in the special weapons box
 a3e_arr_AmmoDepotSpecialWeapons = [];
 // CSAT weapons
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_SVD_des", 50, 2, 4, ["CUP_10Rnd_762x54_SVD_M"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_ksvk", 50, 2, 4, ["CUP_5Rnd_127x108_KSVK_M"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_VSSVintorez_pso", 10, 2, 4, ["CUP_20Rnd_9x39_SP5_VSS_M"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_Pecheneg", 50, 1, 3, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_RPK74", 50, 2, 4, ["CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M","CUP_40Rnd_TE4_LRT4_Green_Tracer_762x39_RPK_M"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_PKM", 30, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M","CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Red_M","CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Yellow_M"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_SVD", 25, 1, 4, ["CUP_10Rnd_762x54_SVD_M"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_ksvk", 10, 1, 2, ["CUP_5Rnd_127x108_KSVK_M"], 9];
 // non-CAST weapons
 a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_arifle_RPK74_45", 50, 2, 4, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M"], 6];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_UK59", 10, 1, 2, ["CUP_50Rnd_UK59_762x54R_Tracer"], 6];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_smg_bizon_snds", 50, 1, 2, ["CUP_64Rnd_9x19_Bizon_M"], 7];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_PKM", 30, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M","CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Red_M","CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Yellow_M"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_SVD", 25, 1, 4, ["CUP_10Rnd_762x54_SVD_M"], 9];
+
 
 
 // Weapons and ammo in the launchers box
 a3e_arr_AmmoDepotLaunchers = [];
 // CSAT weapons
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 2, ["CUP_PG7V_M", "CUP_PG7VL_M", "CUP_PG7VR_M", "CUP_OG7_M"], 1];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG18", 50, 1, 3, ["CUP_RPG18_M"], 1];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 3, ["CUP_PG7V_M"], 3];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Metis", 50, 1, 3, ["CUP_AT13_M"], 2];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Igla", 50, 1, 2, ["CUP_Igla_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 2, ["CUP_PG7V_M", "CUP_PG7VM_M", "CUP_PG7VL_M", "CUP_PG7VR_M", "CUP_OG7_M", "CUP_TBG7V_M"], 2];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG18", 50, 3, 6, ["CUP_RPG18_M"], 0];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Metis", 50, 1, 2, ["CUP_AT13_M", "Vorona_HEAT", "Vorona_HE"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Igla", 50, 1, 2, ["CUP_Igla_M"], 0];
 // non-CSAT weapons
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_MAAWS_Scope", 10, 1, 2, ["CUP_MAAWS_HEAT_M"], 2];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG18", 50, 3, 6, ["CUP_RPG18_M"], 0];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 3, ["CUP_PG7VL_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M47", 50, 1, 2, ["CUP_Dragon_EP1_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_FIM92Stinger", 50, 1, 2, ["CUP_Stinger_M"], 0];
+
+
 //a3e_arr_AmmoDepotLaunchers pushback ["launch_I_Titan_F", 100, 1, 1, ["Titan_AA"], 3];
 //a3e_arr_AmmoDepotLaunchers pushback ["launch_I_Titan_short_F", 100, 1, 1, ["Titan_AP", "Titan_AT"], 3];
 //a3e_arr_AmmoDepotLaunchers pushback ["launch_B_Titan_F", 100, 1, 1, ["Titan_AA"], 3];
@@ -572,27 +1327,27 @@ a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_MAAWS_Scope", 10, 1, 2, ["CUP_M
 // Weapons and ammo in the ordnance box
 a3e_arr_AmmoDepotOrdnance = [];
 // General weapons
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["DemoCharge_Remote_Mag", "SatchelCharge_Remote_Mag"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["APERSMine_Range_Mag", "APERSBoundingMine_Range_Mag", "APERSTripMine_Wire_Mag"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "SLAMDirectionalMine_Wire_Mag"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["Laserbatteries"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["CUP_TimeBomb_M", "CUP_PipeBomb_M"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["CUP_IED_V4_M", "CUP_IED_V3_M", "CUP_IED_V2_M", "CUP_IED_V1_M"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["IEDLandSmall_Remote_Mag", "IEDUrbanSmall_Remote_Mag"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["CUP_MineE_M"], 5];
 
 // Weapons and ammo in the vehicle box (the big one)
 // Some high volumes (mostly for immersion)
 a3e_arr_AmmoDepotVehicle = [];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_HandGrenade_RGO", "CUP_HandGrenade_RGD5"], 50];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_HandGrenade_RGD5", "CUP_HandGrenade_RGO"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["SmokeShell", "SmokeShellYellow", "SmokeShellRed", "SmokeShellGreen", "SmokeShellPurple", "SmokeShellBlue", "SmokeShellOrange"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow"], 50];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_Smoke_M203","CUP_1Rnd_SmokeRed_M203","CUP_1Rnd_SmokeGreen_M203","CUP_1Rnd_SmokeYellow_M203"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_GP25_M"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["FlareWhite_F", "FlareGreen_F", "FlareRed_F", "FlareYellow_F"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_IlumFlareWhite_GP25_M","CUP_IlumFlareRed_GP25_M","CUP_IlumFlareGreen_GP25_M","CUP_FlareWhite_GP25_M","CUP_FlareGreen_GP25_M","CUP_FlareRed_GP25_M","CUP_FlareYellow_GP25_M"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_SMOKE_GP25_M","CUP_1Rnd_SMOKERED_GP25_M","CUP_1Rnd_SMOKEGREEN_GP25_M","CUP_1Rnd_SMOKEYELLOW_GP25_M"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_Smoke_M203","CUP_1Rnd_SmokeRed_M203","CUP_1Rnd_SmokeGreen_M203","CUP_1Rnd_SmokeYellow_M203"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 100, 1, 1, ["CUP_1Rnd_StarCluster_White_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_1Rnd_StarCluster_Green_M203","CUP_1Rnd_StarFlare_White_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarFlare_Green_M203"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_GP25_M", "CUP_1Rnd_SMOKE_GP25_M","CUP_1Rnd_SMOKERED_GP25_M","CUP_1Rnd_SMOKEGREEN_GP25_M","CUP_1Rnd_SMOKEYELLOW_GP25_M"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 100, 1, 1, ["CUP_IlumFlareWhite_GP25_M","CUP_IlumFlareRed_GP25_M","CUP_IlumFlareGreen_GP25_M"], 25];
+
 a3e_arr_AmmoDepotVehicleItems = [];
 a3e_arr_AmmoDepotVehicleItems pushback ["ToolKit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["Medikit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["FirstAidKit", 100, 10, 50, [], 0];
-a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_AlicePack_Khaki"];
+a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_TK_CivPack_WDL_Ammo"];
 
 // Items
 
@@ -601,7 +1356,6 @@ a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_AlicePack_Khaki"];
 // Index 2: Minimum amount.
 // Index 3: Maximum amount.
 a3e_arr_AmmoDepotItems = [];
-a3e_arr_AmmoDepotItems pushback ["Laserdesignator", 10, 1, 2];
 if(Param_NoNightvision==0) then {
 	a3e_arr_AmmoDepotItems pushback ["NVGoggles", 10, 1, 3];
 };
@@ -612,46 +1366,20 @@ a3e_arr_AmmoDepotItems pushback ["ItemGPS", 10, 1, 2];
 a3e_arr_AmmoDepotItems pushback ["ItemMap", 50, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["ItemRadio", 50, 1, 10];
 a3e_arr_AmmoDepotItems pushback ["ItemWatch", 50, 1, 10];
-a3e_arr_AmmoDepotItems pushback ["CUP_acc_Flashlight_desert", 50, 1, 5];
-a3e_arr_AmmoDepotItems pushback ["CUP_acc_ANPEQ_2_desert", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_Bizon", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_PBS4", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_PB6P9", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_Flashlight", 50, 1, 5];
 a3e_arr_AmmoDepotItems pushback ["CUP_optic_Kobra", 20, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1", 20, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3", 20, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PechenegScope", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_HoloDesert", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_snds_G36_desert", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_CQ_T", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_10x40_LRT_Desert", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_ZDDot", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_TrijiconRx01_desert", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PAS_13c2", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_SB_3_12x50_PMII", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM4", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_Eotech533", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_Desert", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1_open", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1_AK", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1_AK_open", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3", 10, 1, 1];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3_open", 10, 1, 1];
 if(Param_NoNightvision==0) then {
-	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_4", 10, 1, 3];
+    a3e_arr_AmmoDepotItems pushback ["CUP_NVG_PVS7", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_NSPU", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_GOSHAWK", 10, 1, 3];
 };
-a3e_arr_AmmoDepotItems pushback ["O_UavTerminal", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_DMS", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_Yorris", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_LRPS", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_AMS", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["optic_KHS_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_01_F_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_02_F_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_03_F_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_01_F_mtp", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_02_F_hex", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_03_F_oli", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["CUP_bipod_VLTOR_Modpod", 20, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["CUP_bipod_Harris_1A2_L", 10, 1, 2];
+
 
 
 // Weapons that may show up in civilian cars
@@ -660,82 +1388,55 @@ a3e_arr_AmmoDepotItems pushback ["CUP_bipod_Harris_1A2_L", 10, 1, 2];
 // Index 1: Magazine classname.
 // Index 2: Number of magazines.
 a3e_arr_CivilianCarWeapons = [];
-a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_TaurusTracker455_gold", "CUP_6Rnd_45ACP_M", 5];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AKS_Gold", "CUP_30Rnd_545x39_AK_M", 5];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Pellets", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_74Slug", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_HE", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AKS74UN_kobra_snds", "CUP_30Rnd_545x39_AK_M", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_glaunch_6G30", "CUP_1Rnd_HE_GP25_M", 8];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_Mk16_CQC_FG", "CUP_30Rnd_556x45_Stanag", 8];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A1_ZDDot_Laser", "CUP_30Rnd_556x45_Stanag", 7];
-a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_M240", "CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M", 5];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 8];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AKS_Gold", "CUP_30Rnd_762x39_AK47_TK_M", 5];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL", "CUP_20Rnd_762x51_FNFAL_M", 7];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL", "CUP_20Rnd_762x51_FNFAL_M", 7];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL", "CUP_20Rnd_762x51_FNFAL_M", 7];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ750_SOS_bipod", "CUP_10Rnd_762x51_CZ750", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 1];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 0];
+a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_SA61","CUP_20Rnd_B_765x17_Ball_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Medikit", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Toolkit", objNull, 0];
 a3e_arr_CivilianCarWeapons pushback ["Binocular", objNull, 0];
-a3e_arr_CivilianCarWeapons pushback [objNull, "SatchelCharge_Remote_Mag", 2];
-a3e_arr_CivilianCarWeapons pushback [objNull, "HandGrenade", 5];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_PipeBomb_M", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_IED_V4_M", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_IED_V3_M", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_IED_V2_M", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_IED_V1_M", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_HandGrenade_RGD5", 5];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_HandGrenade_RGO", 5];
 a3e_arr_CivilianCarWeapons pushback [objNull, "SmokeShell", 5];
 
 
 // Here is a list of scopes:
 a3e_arr_Scopes = [
 	"CUP_optic_Kobra"
-	,"CUP_optic_PSO_1"
-	,"CUP_optic_PSO_3"
-	,"CUP_optic_PechenegScope"
-	,"CUP_optic_SB_3_12x50_PMII"
-	,"CUP_optic_LeupoldMk4"
-	,"CUP_optic_HoloBlack"
-	,"CUP_optic_HoloWdl"
-	,"CUP_optic_HoloDesert"
-	,"CUP_optic_Eotech533"
-	,"CUP_optic_Eotech533Grey"
-	,"CUP_optic_CompM4"
-	,"CUP_optic_SUSAT"
-	,"CUP_optic_ACOG"
-	,"CUP_optic_RCO"
-	,"CUP_optic_RCO_desert"
-	,"CUP_optic_ElcanM145"
-	,"CUP_optic_ELCAN_SpecterDR"
-	,"CUP_optic_LeupoldMk4_CQ_T"
-	,"CUP_optic_ZDDot"];
+	,"CUP_optic_PSO_1_AK"
+	,"CUP_optic_PSO_1_AK_open"];
 a3e_arr_Scopes_SMG = [
-	"CUP_optic_Kobra"
-	,"CUP_optic_Eotech533"
-	,"CUP_optic_ZDDot"];
+	"CUP_optic_Kobra"];
 a3e_arr_Scopes_Sniper = [
 	"CUP_optic_PSO_1"
-	,"CUP_optic_PSO_3"
-	,"CUP_optic_LeupoldMk4"
-	,"CUP_optic_SB_3_12x50_PMII"
-	,"CUP_optic_LeupoldMk4_10x40_LRT_Desert"];
+	,"CUP_optic_PSO_3"];
 a3e_arr_NightScopes = [
-	"CUP_optic_NSPU"
-	,"CUP_optic_AN_PVS_10"
-	,"CUP_optic_AN_PVS_4"];
+	"CUP_optic_NSPU"];
 a3e_arr_TWSScopes = [
-	"CUP_optic_GOSHAWK"
-	,"CUP_optic_AN_PAS_13c2"
-	,"CUP_optic_AN_PAS_13c1"];
+	"CUP_optic_GOSHAWK"];
 
 // Here is a list of bipods, might get randomly added to enemy patrols:
-a3e_arr_Bipods = [
-	"CUP_bipod_VLTOR_Modpod"
-	,"CUP_bipod_Harris_1A2_L"
-	,"bipod_01_F_snd"
-	,"bipod_01_F_blk"
-	,"bipod_01_F_mtp"
-	,"bipod_02_F_blk"
-	,"bipod_02_F_tan"
-	,"bipod_02_F_hex"
-	,"bipod_03_F_blk"
-	,"bipod_03_F_oli"];
+a3e_arr_Bipods = [];
 
 
 //////////////////////////////////////////////////////////////////
@@ -824,22 +1525,23 @@ a3e_arr_AquaticPatrols = [
 // What kind of weapon boxes are spawned when the parameter "additional weapons" is activated
 // use to add boxes from mods to the ammo depots
 //////////////////////////////////////////////////////////////////
-a3e_additional_weapon_box_1 = "CUP_RUBasicWeaponsBox";
-a3e_additional_weapon_box_2 = "CUP_RUSpecialWeaponsBox";
+a3e_additional_weapon_box_1 = "CUP_TKBasicWeapons_EP1";
+a3e_additional_weapon_box_2 = "CUP_TKSpecialWeaponsEP1";
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite
 // mortar spawned in the mortar camps
 //////////////////////////////////////////////////////////////////
 a3e_arr_MortarSite = [
-	"CUP_I_2b14_82mm_AAF"]; //O_Mortar_01_F
+	"CUP_O_2b14_82mm_TK"]; //O_Mortar_01_F
 
 //////////////////////////////////////////////////////////////////
 // fn_CallCAS.sqf
 // Classnames of planes for the CAS module
 //////////////////////////////////////////////////////////////////
 a3e_arr_CASplane = [
-	"CUP_O_Su25_TKA"];
+    "CUP_O_L39_TK"
+	,"CUP_O_Su25_TKA"];
 
 //////////////////////////////////////////////////////////////////
 // fn_CrashSite
@@ -858,33 +1560,34 @@ a3e_arr_CrashSiteWrecks = [
 	,"Land_Wreck_Plane_Transport_01_F"
 	,"Land_Wreck_Heli_Attack_01_F"];
 a3e_arr_CrashSiteCrew = [
-	"CUP_B_US_Pilot"
-	,"CUP_B_US_Pilot_Light"];
+	"CUP_B_GER_HPilot"];
 a3e_arr_CrashSiteWrecksCar = [
-	"Land_Wreck_HMMWV_F"
+     "Land_Wreck_HMMWV_F"
 	,"Land_Wreck_Hunter_F"
-	,"Land_Wreck_Slammer_F"
-	,"M113Wreck"];
+	,"Land_Wreck_Slammer_F"];
 a3e_arr_CrashSiteCrewCar = [
-	"CUP_B_US_Crew"
-	,"CUP_B_US_Soldier_Light"];
+     "CUP_B_GER_BW_Soldier"];
+	 
+	 
+	 
 // Weapons and ammo in crash site box
 a3e_arr_CrashSiteWeapons = [];
-a3e_arr_CrashSiteWeapons pushback ["CUP_sgun_M1014", 50, 2, 5, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 6];
-a3e_arr_CrashSiteWeapons pushback ["CUP_launch_M136", 10, 1, 2, ["CUP_M136_M"], 1];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_G36K_camo", 100, 3, 5, ["CUP_30Rnd_556x45_G36"], 6];
-a3e_arr_CrashSiteWeapons pushback ["CUP_glaunch_M32", 10, 1, 2, ["CUP_6Rnd_HE_M203"], 6];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_G36C_camo_holo_snds", 75, 2, 4, ["CUP_30Rnd_556x45_G36"], 4];
-a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_M60E4", 20, 1, 2, ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], 5];
-a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_M24_des_LeupoldMk4LRT", 10, 1, 2, ["CUP_5Rnd_762x51_M24"], 8];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_MG36", 10, 1, 2, ["CUP_100Rnd_556x45_BetaCMag"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_G36A", 100, 3, 5, ["CUP_30Rnd_556x45_G36"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_smg_MP7_zeiss", 100, 3, 5, ["CUP_40Rnd_46x30_MP7"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_hgun_MP7", 100, 3, 5, ["CUP_20Rnd_46x30_MP7"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_G36K", 75, 3, 5, ["CUP_30Rnd_556x45_G36"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AG36", 75, 2, 4, ["CUP_30Rnd_556x45_G36", "CUP_1Rnd_HEDP_M203"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_G36A", 50, 1, 2, ["CUP_100Rnd_556x45_BetaCMag"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_HK417_20_Scope", 50, 1, 2, ["CUP_20Rnd_762x51_HK417"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_MG3", 25, 1, 2, ["CUP_120Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_launch_MAAWS_Scope", 15, 1, 1, ["CUP_MAAWS_HEAT_M", "CUP_MAAWS_HEDP_M"], 3];
+a3e_arr_CrashSiteWeapons pushback ["CUP_glaunch_M32", 15, 1, 1, ["CUP_6Rnd_HE_M203"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_G22_des_SBPMII", 15, 1, 1, ["CUP_5Rnd_762x67_G22"], 10];
+
 // Attachments and other items in crash site box
 a3e_arr_CrashSiteItems = [];
-a3e_arr_CrashSiteItems pushback ["CUP_muzzle_snds_G36_desert", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_CompM2_Desert", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_RCO_desert", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_ZDDot", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_TrijiconRx01_desert", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_LeupoldMk4_10x40_LRT_Desert", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_acc_ANPEQ_2_desert", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_bipod_Harris_1A2_L", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_muzzle_snds_G36_black", 15, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_muzzle_snds_AWM", 10, 1, 1];
+a3e_arr_CrashSiteItems pushback ["CUP_muzzle_snds_MP7", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_muzzle_snds_SCAR_h", 10, 1, 2];
+a3e_arr_CrashSiteItems pushback ["CUP_acc_ANPEQ_2_grey", 10, 1, 5];

--- a/Mods/CUP Taki/UnitClasses.sqf
+++ b/Mods/CUP Taki/UnitClasses.sqf
@@ -362,6 +362,8 @@ switch (_enemyFrequency) do {
 		//Light AA  1 set
 		,"CUP_O_Ural_ZU23_TKA"
 		,"CUP_O_Ural_ZU23_TKA"
+		,"CUP_O_LR_AA_TKA"
+		,"CUP_O_UAZ_AA_TKA"
 		//Medium AA  1 set
 		,"CUP_O_BMP2_ZU_TKA"
 		,"CUP_O_BMP2_ZU_TKA"
@@ -370,6 +372,8 @@ switch (_enemyFrequency) do {
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
 		,"CUP_O_BTR60_TK"
+		,"CUP_O_BTR80_TK"
+	    ,"CUP_O_BTR80A_TK"
 		,"CUP_O_M113_TKA"
 		,"CUP_O_MTLB_pk_TKA"
 		,"CUP_O_ZSU23_TK"
@@ -381,21 +385,36 @@ switch (_enemyFrequency) do {
 		,"CUP_O_T72_TKA"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
 		//Unarmed Cars  5 sets
-		"CUP_I_Datsun_4seat_TK"  //1
+		"CUP_I_Datsun_4seat_TK"		//1
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //2
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //3
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //4
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //5
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		//Supply Trucks  3 sets
 		,"CUP_I_V3S_Rearm_TKG"  //1
 		,"CUP_I_V3S_Refuel_TKG"
@@ -406,34 +425,56 @@ switch (_enemyFrequency) do {
 		,"CUP_I_V3S_Rearm_TKG"  //3
 		,"CUP_I_V3S_Refuel_TKG"
 		,"CUP_I_V3S_Repair_TKG"
-		//Unarmed MRAPS  1 set
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"	
-		//Armed Cars  1 set
+		//Armed Cars Light 3 sets
+		,"CUP_I_BTR40_MG_TKG"  //1
 		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		,"CUP_I_BTR40_MG_TKG"  //2
 		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		,"CUP_I_BTR40_MG_TKG"  //3
 		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		//MRAPs  2 sets
-		,"CUP_I_BRDM2_TK_Gue"  //1
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		//Armed Cars Heavy  1 set
+		,"CUP_I_Hilux_armored_AGS30_TK"
+		,"CUP_I_Hilux_armored_DSHKM_TK"
+		,"CUP_I_Hilux_armored_M2_TK"
+		,"CUP_I_Hilux_armored_metis_TK"
+		,"CUP_I_Hilux_armored_SPG9_TK"
+		//MRAPs  1 set
+		,"CUP_I_BRDM2_TK_Gue" 
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
-		,"CUP_I_BRDM2_TK_Gue"  //2
-		,"CUP_I_BRDM2_ATGM_TK_Gue"
-		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_Hilux_armored_BMP1_TK"
+		,"CUP_I_Hilux_armored_btr60_TK"
 		// Light AA  1 set
 		,"CUP_I_Ural_ZU23_TK_Gue"
-		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Hilux_igla_TK"
+		,"CUP_I_Hilux_armored_igla_TK"
+		,"CUP_I_Hilux_zu23_TK"
+	    ,"CUP_I_Hilux_armored_zu23_TK" 
 		//Heavily Armed APCs  1 set
 		,"CUP_I_BMP1_TK_GUE"
         ,"CUP_I_BMP1_TK_GUE"
+		//Artillery
+		,"CUP_I_Hilux_MLRS_TK"
+		,"CUP_I_Hilux_podnos_TK"
+		,"CUP_I_Hilux_UB32_TK"
+		,"CUP_I_Hilux_armored_MLRS_TK"
+		,"CUP_I_Hilux_armored_podnos_TK"
+		,"CUP_I_Hilux_armored_UB32_TK"
         //Tanks 1 set
 		,"CUP_I_T34_TK_GUE"
 		,"CUP_I_T55_TK_GUE"];
@@ -528,6 +569,8 @@ switch (_enemyFrequency) do {
 		//Light AA  1 set
 		,"CUP_O_Ural_ZU23_TKA"
 		,"CUP_O_Ural_ZU23_TKA"
+		,"CUP_O_LR_AA_TKA"
+		,"CUP_O_UAZ_AA_TKA"
 		//Medium AA  1 set
 		,"CUP_O_BMP2_ZU_TKA"
 		,"CUP_O_BMP2_ZU_TKA"
@@ -536,6 +579,8 @@ switch (_enemyFrequency) do {
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
 		,"CUP_O_BTR60_TK"
+		,"CUP_O_BTR80_TK"
+	    ,"CUP_O_BTR80A_TK"
 		,"CUP_O_M113_TKA"
 		,"CUP_O_MTLB_pk_TKA"
 		,"CUP_O_ZSU23_TK"
@@ -547,21 +592,36 @@ switch (_enemyFrequency) do {
 		,"CUP_O_T72_TKA"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
 		//Unarmed Cars  5 sets
-		"CUP_I_Datsun_4seat_TK"  //1
+		"CUP_I_Datsun_4seat_TK"		//1
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //2
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //3
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //4
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //5
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		//Supply Trucks  3 sets
 		,"CUP_I_V3S_Rearm_TKG"  //1
 		,"CUP_I_V3S_Refuel_TKG"
@@ -572,50 +632,71 @@ switch (_enemyFrequency) do {
 		,"CUP_I_V3S_Rearm_TKG"  //3
 		,"CUP_I_V3S_Refuel_TKG"
 		,"CUP_I_V3S_Repair_TKG"
-		//Unarmed MRAPS  1 set
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		//Armed Cars  2 sets
-		,"CUP_I_Datsun_PK_TK_Random"  //1
+		//Armed Cars Light 3 sets
+		,"CUP_I_BTR40_MG_TKG"  //1
 		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		,"CUP_I_BTR40_MG_TKG"  //2
 		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		,"CUP_I_BTR40_MG_TKG"  //3
 		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_Datsun_PK_TK_Random"  //2
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		//MRAPs  4 sets
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		//Armed Cars Heavy  2 sets
+		,"CUP_I_Hilux_armored_AGS30_TK"  //1
+		,"CUP_I_Hilux_armored_DSHKM_TK"
+		,"CUP_I_Hilux_armored_M2_TK"
+		,"CUP_I_Hilux_armored_metis_TK"
+		,"CUP_I_Hilux_armored_SPG9_TK"
+		,"CUP_I_Hilux_armored_AGS30_TK"  //2
+		,"CUP_I_Hilux_armored_DSHKM_TK"
+		,"CUP_I_Hilux_armored_M2_TK"
+		,"CUP_I_Hilux_armored_metis_TK"
+		,"CUP_I_Hilux_armored_SPG9_TK"
+		//MRAPs  2 sets
 		,"CUP_I_BRDM2_TK_Gue"  //1
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_Hilux_armored_BMP1_TK"
+		,"CUP_I_Hilux_armored_btr60_TK"
 		,"CUP_I_BRDM2_TK_Gue"  //2
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
-		,"CUP_I_BRDM2_TK_Gue"  //3
-		,"CUP_I_BRDM2_ATGM_TK_Gue"
-		,"CUP_I_BRDM2_HQ_TK_Gue"
-		,"CUP_I_BRDM2_TK_Gue"  //4
-		,"CUP_I_BRDM2_ATGM_TK_Gue"
-		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_Hilux_armored_BMP1_TK"
+		,"CUP_I_Hilux_armored_btr60_TK"
 		// Light AA  2 sets
 		,"CUP_I_Ural_ZU23_TK_Gue"  //1
-		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Hilux_igla_TK"
+		,"CUP_I_Hilux_armored_igla_TK"
+		,"CUP_I_Hilux_zu23_TK"
+	    ,"CUP_I_Hilux_armored_zu23_TK" 
 		,"CUP_I_Ural_ZU23_TK_Gue"  //2
-		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Hilux_igla_TK"
+		,"CUP_I_Hilux_armored_igla_TK"
+		,"CUP_I_Hilux_zu23_TK"
+	    ,"CUP_I_Hilux_armored_zu23_TK" 
 		//Heavily Armed APCs  1 set
 		,"CUP_I_BMP1_TK_GUE"
         ,"CUP_I_BMP1_TK_GUE"
+		//Artillery
+		,"CUP_I_Hilux_MLRS_TK"
+		,"CUP_I_Hilux_podnos_TK"
+		,"CUP_I_Hilux_UB32_TK"
+		,"CUP_I_Hilux_armored_MLRS_TK"
+		,"CUP_I_Hilux_armored_podnos_TK"
+		,"CUP_I_Hilux_armored_UB32_TK"
         //Tanks 1 set
 		,"CUP_I_T34_TK_GUE"
 		,"CUP_I_T55_TK_GUE"];
@@ -710,6 +791,8 @@ switch (_enemyFrequency) do {
 		//Light AA  1 set
 		,"CUP_O_Ural_ZU23_TKA"
 		,"CUP_O_Ural_ZU23_TKA"
+		,"CUP_O_LR_AA_TKA"
+		,"CUP_O_UAZ_AA_TKA"
 		//Medium AA  1 set
 		,"CUP_O_BMP2_ZU_TKA"
 		,"CUP_O_BMP2_ZU_TKA"
@@ -718,6 +801,8 @@ switch (_enemyFrequency) do {
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
 		,"CUP_O_BTR60_TK"
+		,"CUP_O_BTR80_TK"
+	    ,"CUP_O_BTR80A_TK"
 		,"CUP_O_M113_TKA"
 		,"CUP_O_MTLB_pk_TKA"
 		,"CUP_O_ZSU23_TK"
@@ -725,35 +810,51 @@ switch (_enemyFrequency) do {
 		,"CUP_O_BMP1P_TKA"
 		,"CUP_O_BMP2_TKA"
 		,"CUP_O_BTR60_TK"
+		,"CUP_O_BTR80_TK"
+	    ,"CUP_O_BTR80A_TK"
 		,"CUP_O_M113_TKA"
 		,"CUP_O_MTLB_pk_TKA"
 		,"CUP_O_ZSU23_TK"
 		//Artillery
 		,"CUP_O_BM21_TKA"
-		//Tanks 2 sets
+		//Tanks 1 set with extra T72s
 		,"CUP_O_T34_TKA"
 		,"CUP_O_T55_TK"
 		,"CUP_O_T72_TKA"
-		,"CUP_O_T34_TKA"
-		,"CUP_O_T55_TK"
+		,"CUP_O_T72_TKA"
 		,"CUP_O_T72_TKA"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
 		//Unarmed Cars  5 sets
-		"CUP_I_Datsun_4seat_TK"  //1
+		"CUP_I_Datsun_4seat_TK"		//1
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //2
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //3
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //4
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		,"CUP_I_Datsun_4seat_TK"  //5
+		,"CUP_I_Hilux_unarmed_TK"
+		,"CUP_I_Hilux_armored_unarmed_TK"
 		,"CUP_I_V3S_Open_TKG"
 		,"CUP_I_V3S_Covered_TKG"
+		,"CUP_I_BTR40_TKG"
 		//Supply Trucks  3 sets
 		,"CUP_I_V3S_Rearm_TKG"  //1
 		,"CUP_I_V3S_Refuel_TKG"
@@ -764,63 +865,80 @@ switch (_enemyFrequency) do {
 		,"CUP_I_V3S_Rearm_TKG"  //3
 		,"CUP_I_V3S_Refuel_TKG"
 		,"CUP_I_V3S_Repair_TKG"
-		//Unarmed MRAPS  1 set
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		,"CUP_I_BTR40_TKG"
-		//Armed Cars  2 sets
-		,"CUP_I_Datsun_PK_TK_Random"  //1
+		//Armed Cars Light 3 sets
+		,"CUP_I_BTR40_MG_TKG"  //1
 		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		,"CUP_I_BTR40_MG_TKG"  //2
 		,"CUP_I_Datsun_PK_TK_Random"
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		,"CUP_I_BTR40_MG_TKG"  //3
 		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_Datsun_PK_TK_Random"  //2
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_Datsun_PK_TK_Random"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		,"CUP_I_BTR40_MG_TKG"
-		//MRAPs  4 sets
+		,"CUP_I_Hilux_AGS30_TK"
+		,"CUP_I_Hilux_DSHKM_TK"
+		,"CUP_I_Hilux_M2_TK"
+		,"CUP_I_Hilux_metis_TK"
+		,"CUP_I_Hilux_SPG9_TK"
+		//Armed Cars Heavy  2 sets
+		,"CUP_I_Hilux_armored_AGS30_TK"  //1
+		,"CUP_I_Hilux_armored_DSHKM_TK"
+		,"CUP_I_Hilux_armored_M2_TK"
+		,"CUP_I_Hilux_armored_metis_TK"
+		,"CUP_I_Hilux_armored_SPG9_TK"
+		,"CUP_I_Hilux_armored_AGS30_TK"  //2
+		,"CUP_I_Hilux_armored_DSHKM_TK"
+		,"CUP_I_Hilux_armored_M2_TK"
+		,"CUP_I_Hilux_armored_metis_TK"
+		,"CUP_I_Hilux_armored_SPG9_TK"
+		//MRAPs  2 sets
 		,"CUP_I_BRDM2_TK_Gue"  //1
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
+		,"CUP_I_Hilux_armored_BMP1_TK"
+		,"CUP_I_Hilux_armored_btr60_TK"
 		,"CUP_I_BRDM2_TK_Gue"  //2
 		,"CUP_I_BRDM2_ATGM_TK_Gue"
 		,"CUP_I_BRDM2_HQ_TK_Gue"
-		,"CUP_I_BRDM2_TK_Gue"  //3
-		,"CUP_I_BRDM2_ATGM_TK_Gue"
-		,"CUP_I_BRDM2_HQ_TK_Gue"
-		,"CUP_I_BRDM2_TK_Gue"  //4
-		,"CUP_I_BRDM2_ATGM_TK_Gue"
-		,"CUP_I_BRDM2_HQ_TK_Gue"
-		// Light AA  3 sets
+		,"CUP_I_Hilux_armored_BMP1_TK"
+		,"CUP_I_Hilux_armored_btr60_TK"
+		// Light AA  2 sets
 		,"CUP_I_Ural_ZU23_TK_Gue"  //1
-		,"CUP_I_Ural_ZU23_TK_Gue"
+		,"CUP_I_Hilux_igla_TK"
+		,"CUP_I_Hilux_armored_igla_TK"
+		,"CUP_I_Hilux_zu23_TK"
+	    ,"CUP_I_Hilux_armored_zu23_TK" 
 		,"CUP_I_Ural_ZU23_TK_Gue"  //2
-		,"CUP_I_Ural_ZU23_TK_Gue"
-		,"CUP_I_Ural_ZU23_TK_Gue"  //3
-		,"CUP_I_Ural_ZU23_TK_Gue"
-		//Heavily Armed APCs  3 sets
+		,"CUP_I_Hilux_igla_TK"
+		,"CUP_I_Hilux_armored_igla_TK"
+		,"CUP_I_Hilux_zu23_TK"
+	    ,"CUP_I_Hilux_armored_zu23_TK" 
+		//Heavily Armed APCs  2 sets
 		,"CUP_I_BMP1_TK_GUE"  //1
         ,"CUP_I_BMP1_TK_GUE"
 		,"CUP_I_BMP1_TK_GUE"  //2
         ,"CUP_I_BMP1_TK_GUE"
-		,"CUP_I_BMP1_TK_GUE"  //3
-        ,"CUP_I_BMP1_TK_GUE"
+		//Artillery
+		,"CUP_I_Hilux_MLRS_TK"
+		,"CUP_I_Hilux_podnos_TK"
+		,"CUP_I_Hilux_UB32_TK"
+		,"CUP_I_Hilux_armored_MLRS_TK"
+		,"CUP_I_Hilux_armored_podnos_TK"
+		,"CUP_I_Hilux_armored_UB32_TK"
         //Tanks 2 sets
 		,"CUP_I_T34_TK_GUE"  //1
 		,"CUP_I_T55_TK_GUE"
 		,"CUP_I_T34_TK_GUE"  //2
 		,"CUP_I_T55_TK_GUE"];
     };
-};
+};	
 
 // Random array. General infantry types. E.g. village patrols, ambient infantry, ammo depot guards, communication center guards, etc.
 a3e_arr_Escape_InfantryTypes = [
@@ -861,8 +979,6 @@ a3e_arr_Escape_InfantryTypes = [
 	,"CUP_O_TK_Soldier_SL"
 	,"CUP_O_TK_Officer"
 	,"CUP_O_TK_Spotter"
-	,"CUP_O_TK_Sniper"
-	,"CUP_O_TK_Sniper_KSVK"
 	,"CUP_O_TK_Commander"
 	,"CUP_O_TK_Soldier_M"
 	,"CUP_O_TK_Soldier_M"
@@ -880,14 +996,16 @@ a3e_arr_Escape_InfantryTypes_Ind =  [
 	,"CUP_I_TK_GUE_Soldier"
 	,"CUP_I_TK_GUE_Soldier"
 	,"CUP_I_TK_GUE_Soldier"
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Soldier_AK_47S"
+	,"CUP_I_TK_GUE_Soldier_HAT"
+	,"CUP_I_TK_GUE_Guerilla_Enfield"
+	,"CUP_I_TK_GUE_Guerilla_Enfield"
+	,"CUP_I_TK_GUE_Guerilla_Enfield"
 	,"CUP_I_TK_GUE_Soldier_GL"
 	,"CUP_I_TK_GUE_Soldier_GL"
-	,"CUP_I_TK_GUE_Soldier_AK_47S"
-	,"CUP_I_TK_GUE_Soldier_AK_47S"
-	,"CUP_I_TK_GUE_Soldier_AK_47S"
-	,"CUP_I_TK_GUE_Guerilla_Enfield"
-	,"CUP_I_TK_GUE_Guerilla_Enfield"
-	,"CUP_I_TK_GUE_Guerilla_Enfield"
+	,"CUP_I_TK_GUE_Soldier_M16A2"
 	,"CUP_I_TK_GUE_Soldier_AAT"
 	,"CUP_I_TK_GUE_Soldier_AAT"
 	,"CUP_I_TK_GUE_Soldier_LAT"
@@ -957,6 +1075,8 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 	,"CUP_O_BMP2_TKA"
 	,"CUP_O_BMP2_ZU_TKA"
 	,"CUP_O_BTR60_TK"
+	,"CUP_O_BTR80_TK"
+	,"CUP_O_BTR80A_TK"
 	,"CUP_O_M113_TKA"
 	,"CUP_O_MTLB_pk_TKA"];
 
@@ -1253,14 +1373,13 @@ a3e_arr_O_attack_heli = [
 	"CUP_O_Mi24_D_TK"];
 a3e_arr_O_transport_heli = [
 	"CUP_O_Mi17_TK"
-	,"CUP_O_UH1H_TKA"
 	,"CUP_O_MI6T_TKA"];
 a3e_arr_O_pilots = [
 	"CUP_O_TK_Pilot"];
 a3e_arr_I_transport_heli = [
 	"CUP_I_UH1H_TK_GUE"];
 a3e_arr_I_pilots = [
-	"CUP_O_TK_GUE_Soldier"];
+	"CUP_I_TK_GUE_Soldier"];
 
 
 // The following arrays define weapons and ammo contained at the ammo depots

--- a/Mods/CUP-CDF winter/UnitClasses.sqf
+++ b/Mods/CUP-CDF winter/UnitClasses.sqf
@@ -24,71 +24,284 @@ A3E_VAR_Side_Ind_Str = format["%1",A3E_VAR_Side_Ind];
 
 // Random array. Start position guard types around the prison.
 a3e_arr_Escape_StartPositionGuardTypes = [
-	"CUP_I_PMC_Winter_Soldier_M4A3"
+	"CUP_I_PMC_Winter_Soldier"
 	,"CUP_I_PMC_Winter_Soldier"
+	,"CUP_I_PMC_Winter_soldier_MG"
 	,"CUP_I_PMC_Winter_Soldier_GL"];
 
 // Prison backpack secondary weapon (and corresponding magazine type).
 a3e_arr_PrisonBackpackWeapons = [];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911","CUP_7Rnd_45ACP_1911"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Colt1911_snds","CUP_7Rnd_45ACP_1911"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Compact","CUP_10Rnd_9x19_Compact"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Duty","16Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Duty_M3X","16Rnd_9x21_Mag"];
+//Pistols
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Glock17_blk","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_flashlight_snds","CUP_17Rnd_9x19_glock17"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_blk_snds","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_flashlight","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_snds","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_flashlight_snds","CUP_17Rnd_9x19_glock17"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9","CUP_15Rnd_9x19_M9"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_M9_snds","CUP_15Rnd_9x19_M9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_glock17_snds","CUP_17Rnd_9x19_glock17"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Makarov","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9","CUP_8Rnd_9x18_Makarov_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9_snds","CUP_8Rnd_9x18_MakarovSD_M"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19_UZI"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Phantom","CUP_18Rnd_9x19_Phantom"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Phantom_Flashlight","CUP_18Rnd_9x19_Phantom"];
-a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Phantom_Flashlight_snds","CUP_18Rnd_9x19_Phantom"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_PB6P9_snds","CUP_8Rnd_9x18_MakarovSD_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_32Rnd_9x19_TEC9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_32Rnd_9x19_TEC9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_32Rnd_9x19_TEC9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_32Rnd_9x19_TEC9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TEC9","CUP_32Rnd_9x19_TEC9"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455","CUP_6Rnd_45ACP_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_TaurusTracker455_gold","CUP_6Rnd_45ACP_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Deagle","CUP_7Rnd_50AE_Deagle"];
+//SMGs
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi","CUP_30Rnd_9x19_UZI"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
 a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_SA61","CUP_20Rnd_B_765x17_Ball_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_smg_SA61","CUP_20Rnd_B_765x17_Ball_M"];
+a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_Mac10","CUP_30Rnd_45ACP_MAC10_M"];
+
 
 // Random array. Civilian vehicle classes for ambient traffic.
 a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
-	"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_03"
+	"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
 	,"CUP_C_Datsun"
 	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_camo_Civ"
+	,"CUP_C_Golf4_camodark_Civ"
+	,"CUP_C_Golf4_camodigital_Civ"
+	,"CUP_C_Golf4_crowe_Civ"
+	,"CUP_C_Golf4_kitty_Civ"
+	,"CUP_C_Golf4_reptile_Civ"
+	,"CUP_C_Golf4_whiteblood_Civ"
 	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
+	,"CUP_C_TT650_CIV"
 	,"CUP_C_Skoda_Blue_CIV"
 	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Golf4_red_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_SUV_CIV"
-	,"C_Hatchback_01_F"
-	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
-	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
-	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
-	,"C_Truck_02_covered_F"
-	,"C_Offroad_01_repair_F"
-	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"];
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Tractor_Old_CIV"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+    ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_TT650_TK_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"];
 	if(Param_UseDLCApex==1) then {
 	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Offroad_02_unarmed_F";
 	};
@@ -104,53 +317,78 @@ a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 switch (_enemyFrequency) do {
     case 1: {//Few (1-3)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"CUP_B_UAZ_Unarmed_CDF"
-		,"CUP_B_UAZ_MG_CDF"
-		,"CUP_B_UAZ_AGS30_CDF"
-		,"CUP_B_UAZ_METIS_CDF"
+		//Unarmed Cars  2 sets
+		"CUP_B_S1203_Ambulance_CDF"  //1
+		,"CUP_B_UAZ_Unarmed_CDF"
 		,"CUP_B_UAZ_Open_CDF"
-		,"CUP_B_UAZ_SPG9_CDF"
+		,"CUP_B_Kamaz_CDF"
+		,"CUP_B_Kamaz_Open_CDF"
 		,"CUP_B_Ural_CDF"
-		,"CUP_B_Ural_Reammo_CDF"
 		,"CUP_B_Ural_Empty_CDF"
 		,"CUP_B_Ural_Open_CDF"
-		,"CUP_B_Ural_Refuel_CDF"
-		,"CUP_B_Ural_Repair_CDF"
+		,"CUP_B_S1203_Ambulance_CDF"  //2
+		,"CUP_B_UAZ_Unarmed_CDF"
+		,"CUP_B_UAZ_Open_CDF"
 		,"CUP_B_Kamaz_CDF"
+		,"CUP_B_Kamaz_Open_CDF"
+		,"CUP_B_Ural_CDF"
+		,"CUP_B_Ural_Empty_CDF"
+		,"CUP_B_Ural_Open_CDF"
+		//Supply Trucks  1 set
 		,"CUP_B_Kamaz_Reammo_CDF"
 		,"CUP_B_Kamaz_Refuel_CDF"
-		,"CUP_B_Kamaz_Open_CDF"
 		,"CUP_B_Kamaz_Repair_CDF"
-		,"CUP_B_S1203_Ambulance_CDF"
-		,"CUP_B_Ural_ZU23_CDF"
-		,"CUP_B_ZSU23_CDF"
-		,"CUP_B_ZSU23_Afghan_CDF"
-		,"CUP_B_BMP2_CDF"
+		,"CUP_B_Ural_Reammo_CDF"
+		,"CUP_B_Ural_Refuel_CDF"
+		,"CUP_B_Ural_Repair_CDF"
+		//Unarmed APCs  1 set
 		,"CUP_B_BMP2_AMB_CDF"
-		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP2_AMB_CDF"
+		,"CUP_B_BMP2_AMB_CDF"
+		//Armed Cars  1 set
+		,"CUP_B_Ural_ZU23_CDF"
+		,"CUP_B_UAZ_AGS30_CDF"
+		,"CUP_B_UAZ_MG_CDF"
+		,"CUP_B_UAZ_METIS_CDF"
+		,"CUP_B_UAZ_SPG9_CDF"
+		//MRAPS  1 set
 		,"CUP_B_BRDM2_CDF"
 		,"CUP_B_BRDM2_ATGM_CDF"
 		,"CUP_B_BRDM2_HQ_CDF"
+		//Light armed APCs  1 set
+		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP_HQ_CDF"
+		//Heavily Armed APCs or AA  1 set
+		,"CUP_B_ZSU23_CDF"
+		,"CUP_B_ZSU23_Afghan_CDF"
+		,"CUP_B_BMP2_CDF"
 		,"CUP_B_BTR60_CDF"
 		,"CUP_B_MTLB_pk_Winter_CDF"
+		//Artillery  1 set
 		,"CUP_B_BM21_CDF"
+		//Tanks  1 set
 		,"CUP_B_T72_CDF"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars  1 set
 		"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		//Armed Cars
 		,"CUP_I_SUV_Armored_ION"
-		,"CUP_I_FENNEK_ION"
-		,"CUP_I_FENNEK_GMG_ION"
-		,"CUP_I_FENNEK_HMG_ION"
-		,"CUP_I_MATV_ION"
-		,"CUP_I_MATV_GMG_ION"
-		,"CUP_I_MATV_HMG_ION"];
+		//MRAPS
+        ,"CUP_I_RG31_Mk19_W_ION"
+		,"CUP_I_RG31E_M2_W_ION"
+		,"CUP_I_RG31_M2_W_GC_ION"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_AT_ION";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_LMG_ION";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_unarmed_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_AT_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_Minigun_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_unarmed_ION";
 		};
 		if(Param_UseDLCLaws==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_Van_ammo_ION";
@@ -161,53 +399,90 @@ switch (_enemyFrequency) do {
     };
     case 2: {//Some (4-6)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"CUP_B_UAZ_Unarmed_CDF"
-		,"CUP_B_UAZ_MG_CDF"
-		,"CUP_B_UAZ_AGS30_CDF"
-		,"CUP_B_UAZ_METIS_CDF"
+		//Unarmed Cars  2 sets
+		"CUP_B_S1203_Ambulance_CDF"  //1
+		,"CUP_B_UAZ_Unarmed_CDF"
 		,"CUP_B_UAZ_Open_CDF"
-		,"CUP_B_UAZ_SPG9_CDF"
+		,"CUP_B_Kamaz_CDF"
+		,"CUP_B_Kamaz_Open_CDF"
 		,"CUP_B_Ural_CDF"
-		,"CUP_B_Ural_Reammo_CDF"
 		,"CUP_B_Ural_Empty_CDF"
 		,"CUP_B_Ural_Open_CDF"
-		,"CUP_B_Ural_Refuel_CDF"
-		,"CUP_B_Ural_Repair_CDF"
+		,"CUP_B_S1203_Ambulance_CDF"  //2
+		,"CUP_B_UAZ_Unarmed_CDF"
+		,"CUP_B_UAZ_Open_CDF"
 		,"CUP_B_Kamaz_CDF"
+		,"CUP_B_Kamaz_Open_CDF"
+		,"CUP_B_Ural_CDF"
+		,"CUP_B_Ural_Empty_CDF"
+		,"CUP_B_Ural_Open_CDF"
+		//Supply Trucks  1 set
 		,"CUP_B_Kamaz_Reammo_CDF"
 		,"CUP_B_Kamaz_Refuel_CDF"
-		,"CUP_B_Kamaz_Open_CDF"
 		,"CUP_B_Kamaz_Repair_CDF"
-		,"CUP_B_S1203_Ambulance_CDF"
-		,"CUP_B_Ural_ZU23_CDF"
-		,"CUP_B_ZSU23_CDF"
-		,"CUP_B_ZSU23_Afghan_CDF"
-		,"CUP_B_BMP2_CDF"
+		,"CUP_B_Ural_Reammo_CDF"
+		,"CUP_B_Ural_Refuel_CDF"
+		,"CUP_B_Ural_Repair_CDF"
+		//Unarmed APCs  1 set
 		,"CUP_B_BMP2_AMB_CDF"
-		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP2_AMB_CDF"
+		,"CUP_B_BMP2_AMB_CDF"
+		//Armed Cars  2 sets
+		,"CUP_B_Ural_ZU23_CDF"  //1
+		,"CUP_B_UAZ_AGS30_CDF"
+		,"CUP_B_UAZ_MG_CDF"
+		,"CUP_B_UAZ_METIS_CDF"
+		,"CUP_B_UAZ_SPG9_CDF"
+		,"CUP_B_Ural_ZU23_CDF"  //2
+		,"CUP_B_UAZ_AGS30_CDF"
+		,"CUP_B_UAZ_MG_CDF"
+		,"CUP_B_UAZ_METIS_CDF"
+		,"CUP_B_UAZ_SPG9_CDF"
+		//MRAPS  2 sets
 		,"CUP_B_BRDM2_CDF"
 		,"CUP_B_BRDM2_ATGM_CDF"
 		,"CUP_B_BRDM2_HQ_CDF"
+		,"CUP_B_BRDM2_CDF"
+		,"CUP_B_BRDM2_ATGM_CDF"
+		,"CUP_B_BRDM2_HQ_CDF"
+		//Light armed APCs  1 set
+		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP_HQ_CDF"
+		//Heavily Armed APCs or AA  1 set
+		,"CUP_B_ZSU23_CDF"
+		,"CUP_B_ZSU23_Afghan_CDF"
+		,"CUP_B_BMP2_CDF"
 		,"CUP_B_BTR60_CDF"
 		,"CUP_B_MTLB_pk_Winter_CDF"
+		//Artillery  1 set
 		,"CUP_B_BM21_CDF"
+		//Tanks  1 set
 		,"CUP_B_T72_CDF"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars  1 set
 		"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		//Armed Cars  2 sets
 		,"CUP_I_SUV_Armored_ION"
-		,"CUP_I_FENNEK_ION"
-		,"CUP_I_FENNEK_GMG_ION"
-		,"CUP_I_FENNEK_HMG_ION"
-		,"CUP_I_MATV_ION"
-		,"CUP_I_MATV_GMG_ION"
-		,"CUP_I_MATV_HMG_ION"];
+		,"CUP_I_SUV_Armored_ION"
+		//MRAPS  2 sets
+        ,"CUP_I_RG31_Mk19_W_ION"  //1
+		,"CUP_I_RG31E_M2_W_ION"
+		,"CUP_I_RG31_M2_W_GC_ION"
+		,"CUP_I_RG31_Mk19_W_ION"  //2
+		,"CUP_I_RG31E_M2_W_ION"
+		,"CUP_I_RG31_M2_W_GC_ION"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_AT_ION";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_LMG_ION";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_unarmed_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_AT_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_Minigun_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_unarmed_ION";
 		};
 		if(Param_UseDLCLaws==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_Van_ammo_ION";
@@ -218,53 +493,96 @@ switch (_enemyFrequency) do {
     };
     default {//A lot (7-8)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"CUP_B_UAZ_Unarmed_CDF"
-		,"CUP_B_UAZ_MG_CDF"
-		,"CUP_B_UAZ_AGS30_CDF"
-		,"CUP_B_UAZ_METIS_CDF"
+		//Unarmed Cars  2 sets
+		"CUP_B_S1203_Ambulance_CDF"  //1
+		,"CUP_B_UAZ_Unarmed_CDF"
 		,"CUP_B_UAZ_Open_CDF"
-		,"CUP_B_UAZ_SPG9_CDF"
+		,"CUP_B_Kamaz_CDF"
+		,"CUP_B_Kamaz_Open_CDF"
 		,"CUP_B_Ural_CDF"
-		,"CUP_B_Ural_Reammo_CDF"
 		,"CUP_B_Ural_Empty_CDF"
 		,"CUP_B_Ural_Open_CDF"
-		,"CUP_B_Ural_Refuel_CDF"
-		,"CUP_B_Ural_Repair_CDF"
+		,"CUP_B_S1203_Ambulance_CDF"  //2
+		,"CUP_B_UAZ_Unarmed_CDF"
+		,"CUP_B_UAZ_Open_CDF"
 		,"CUP_B_Kamaz_CDF"
+		,"CUP_B_Kamaz_Open_CDF"
+		,"CUP_B_Ural_CDF"
+		,"CUP_B_Ural_Empty_CDF"
+		,"CUP_B_Ural_Open_CDF"
+		//Supply Trucks  1 set
 		,"CUP_B_Kamaz_Reammo_CDF"
 		,"CUP_B_Kamaz_Refuel_CDF"
-		,"CUP_B_Kamaz_Open_CDF"
 		,"CUP_B_Kamaz_Repair_CDF"
-		,"CUP_B_S1203_Ambulance_CDF"
-		,"CUP_B_Ural_ZU23_CDF"
-		,"CUP_B_ZSU23_CDF"
-		,"CUP_B_ZSU23_Afghan_CDF"
-		,"CUP_B_BMP2_CDF"
+		,"CUP_B_Ural_Reammo_CDF"
+		,"CUP_B_Ural_Refuel_CDF"
+		,"CUP_B_Ural_Repair_CDF"
+		//Unarmed APCs  1 set
 		,"CUP_B_BMP2_AMB_CDF"
-		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP2_AMB_CDF"
+		,"CUP_B_BMP2_AMB_CDF"
+		//Armed Cars  2 sets
+		,"CUP_B_Ural_ZU23_CDF"  //1
+		,"CUP_B_UAZ_AGS30_CDF"
+		,"CUP_B_UAZ_MG_CDF"
+		,"CUP_B_UAZ_METIS_CDF"
+		,"CUP_B_UAZ_SPG9_CDF"
+		,"CUP_B_Ural_ZU23_CDF"  //2
+		,"CUP_B_UAZ_AGS30_CDF"
+		,"CUP_B_UAZ_MG_CDF"
+		,"CUP_B_UAZ_METIS_CDF"
+		,"CUP_B_UAZ_SPG9_CDF"
+		//MRAPS  2 sets
 		,"CUP_B_BRDM2_CDF"
 		,"CUP_B_BRDM2_ATGM_CDF"
 		,"CUP_B_BRDM2_HQ_CDF"
+		,"CUP_B_BRDM2_CDF"
+		,"CUP_B_BRDM2_ATGM_CDF"
+		,"CUP_B_BRDM2_HQ_CDF"
+		//Light armed APCs  1 set
+		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP_HQ_CDF"
+		,"CUP_B_BMP_HQ_CDF"
+		//Heavily Armed APCs or AA  2 sets
+		,"CUP_B_ZSU23_CDF"  //1
+		,"CUP_B_ZSU23_Afghan_CDF"
+		,"CUP_B_BMP2_CDF"
 		,"CUP_B_BTR60_CDF"
 		,"CUP_B_MTLB_pk_Winter_CDF"
+		,"CUP_B_ZSU23_CDF"  //2
+		,"CUP_B_ZSU23_Afghan_CDF"
+		,"CUP_B_BMP2_CDF"
+		,"CUP_B_BTR60_CDF"
+		,"CUP_B_MTLB_pk_Winter_CDF"
+		//Artillery  1 set
 		,"CUP_B_BM21_CDF"
+		//Tanks  2 sets
+		,"CUP_B_T72_CDF"
 		,"CUP_B_T72_CDF"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars  1 set
 		"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		,"CUP_I_SUV_ION"
+		//Armed Cars  2 sets
 		,"CUP_I_SUV_Armored_ION"
-		,"CUP_I_FENNEK_ION"
-		,"CUP_I_FENNEK_GMG_ION"
-		,"CUP_I_FENNEK_HMG_ION"
-		,"CUP_I_MATV_ION"
-		,"CUP_I_MATV_GMG_ION"
-		,"CUP_I_MATV_HMG_ION"];
+		,"CUP_I_SUV_Armored_ION"
+		//MRAPS  2 sets
+        ,"CUP_I_RG31_Mk19_W_ION"  //1
+		,"CUP_I_RG31E_M2_W_ION"
+		,"CUP_I_RG31_M2_W_GC_ION"
+		,"CUP_I_RG31_Mk19_W_ION"  //2
+		,"CUP_I_RG31E_M2_W_ION"
+		,"CUP_I_RG31_M2_W_GC_ION"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_AT_ION";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_LMG_ION";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_unarmed_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_AT_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_Minigun_ION";
-		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_LSV_02_unarmed_ION";
 		};
 		if(Param_UseDLCLaws==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_Van_ammo_ION";
@@ -279,15 +597,17 @@ switch (_enemyFrequency) do {
 a3e_arr_Escape_InfantryTypes = [
 	"CUP_B_CDF_Soldier_SNW"
 	,"CUP_B_CDF_Soldier_AA_SNW"
+	,"CUP_B_CDF_Soldier_AAT_SNW"
+	,"CUP_B_CDF_Soldier_AMG_SNW"
 	,"CUP_B_CDF_Soldier_LAT_SNW"
 	,"CUP_B_CDF_Soldier_LAT_SNW"
 	,"CUP_B_CDF_Soldier_AR_SNW"
-	,"CUP_B_CDF_Commander_SNW"
 	,"CUP_B_CDF_Soldier_GL_SNW"
 	,"CUP_B_CDF_Soldier_MG_SNW"
 	,"CUP_B_CDF_Soldier_Marksman_SNW"
 	,"CUP_B_CDF_Militia_SNW"
 	,"CUP_B_CDF_Officer_SNW"
+	,"CUP_B_CDF_Soldier_RPG18_SNW"
 	,"CUP_B_CDF_Sniper_SNW"
 	,"CUP_B_CDF_Spotter_SNW"
 	,"CUP_B_CDF_Soldier_TL_SNW"
@@ -299,7 +619,6 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	"CUP_I_PMC_Winter_Soldier_TL"
 	,"CUP_I_PMC_Winter_Soldier"
 	,"CUP_I_PMC_Winter_Soldier_GL"
-	,"CUP_I_PMC_Winter_Soldier_M4A3"
 	,"CUP_I_PMC_Winter_Soldier_MG"
 	,"CUP_I_PMC_Winter_Soldier_MG_PKM"
 	,"CUP_I_PMC_Winter_Soldier_AA"
@@ -313,15 +632,17 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 a3e_arr_recon_InfantryTypes = [
 	"CUP_B_CDF_Soldier_SNW"
 	,"CUP_B_CDF_Soldier_AA_SNW"
+	,"CUP_B_CDF_Soldier_AAT_SNW"
+	,"CUP_B_CDF_Soldier_AMG_SNW"
 	,"CUP_B_CDF_Soldier_LAT_SNW"
 	,"CUP_B_CDF_Soldier_LAT_SNW"
 	,"CUP_B_CDF_Soldier_AR_SNW"
-	,"CUP_B_CDF_Commander_SNW"
 	,"CUP_B_CDF_Soldier_GL_SNW"
 	,"CUP_B_CDF_Soldier_MG_SNW"
 	,"CUP_B_CDF_Soldier_Marksman_SNW"
 	,"CUP_B_CDF_Militia_SNW"
 	,"CUP_B_CDF_Officer_SNW"
+	,"CUP_B_CDF_Soldier_RPG18_SNW"
 	,"CUP_B_CDF_Sniper_SNW"
 	,"CUP_B_CDF_Spotter_SNW"
 	,"CUP_B_CDF_Soldier_TL_SNW"
@@ -333,7 +654,6 @@ a3e_arr_recon_I_InfantryTypes = [
 	"CUP_I_PMC_Winter_Soldier_TL"
 	,"CUP_I_PMC_Winter_Soldier"
 	,"CUP_I_PMC_Winter_Soldier_GL"
-	,"CUP_I_PMC_Winter_Soldier_M4A3"
 	,"CUP_I_PMC_Winter_Soldier_MG"
 	,"CUP_I_PMC_Winter_Soldier_MG_PKM"
 	,"CUP_I_PMC_Winter_Soldier_AA"
@@ -347,10 +667,8 @@ a3e_arr_recon_I_InfantryTypes = [
 
 // Random array. A roadblock has a manned vehicle. This array contains possible manned vehicles (can be of any kind, like cars, armored and statics).
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
-	"CUP_B_BRDM2_HQ_CDF"
-	,"CUP_B_BRDM2_ATGM_CDF"
+	"CUP_B_BRDM2_ATGM_CDF"
 	,"CUP_B_BRDM2_CDF"
-	,"CUP_B_BMP_HQ_CDF"
 	,"CUP_B_BTR60_CDF"
 	,"CUP_B_MTLB_pk_Winter_CDF"
 	,"CUP_B_UAZ_MG_CDF"
@@ -358,18 +676,15 @@ a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
 	,"CUP_B_UAZ_SPG9_CDF"
 	,"CUP_B_UAZ_AGS30_CDF"];
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind = [
-	"CUP_I_SUV_ION"
+	"CUP_I_SUV_Armored_ION"
 	,"CUP_I_SUV_Armored_ION"
-	,"CUP_I_SUV_Armored_ION"
-	,"CUP_I_FENNEK_GMG_ION"
-	,"CUP_I_FENNEK_HMG_ION"
-	,"CUP_I_MATV_GMG_ION"
-	,"CUP_I_MATV_HMG_ION"];
+    ,"CUP_I_RG31_Mk19_W_ION"
+    ,"CUP_I_RG31E_M2_W_ION"
+    ,"CUP_I_RG31_M2_W_GC_ION"];
 	if(Param_UseDLCApex==1) then {
-	a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "CUP_I_4WD_AT_ION";
-	a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "CUP_I_4WD_LMG_ION";
-	a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "CUP_I_LSV_02_AT_ION";
-	a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "CUP_I_LSV_02_Minigun_ION";
+	a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_AT_ION";
+	a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_LMG_ION";
+	a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_unarmed_ION";
 	};
 
 // Random array. Vehicle classes (preferrably trucks) transporting enemy reinforcements.
@@ -377,16 +692,9 @@ a3e_arr_Escape_ReinforcementTruck_vehicleClasses = [
 	"CUP_B_Ural_CDF"
 	,"CUP_B_Ural_Open_CDF"
 	,"CUP_B_Kamaz_CDF"
-	,"CUP_B_Kamaz_Open_CDF"
-	,"CUP_B_MTLB_pk_Winter_CDF"
-	,"CUP_B_MTLB_pk_Winter_CDF"
-	,"CUP_B_BRDM2_CDF"];
+	,"CUP_B_Kamaz_Open_CDF"];
 a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind = [
-	"CUP_I_SUV_ION"
-	,"CUP_I_SUV_Armored_ION"
-	,"CUP_I_SUV_ION"
-	,"CUP_I_FENNEK_ION"
-	,"CUP_I_MATV_ION"];
+	"CUP_I_SUV_ION"];
 	if(Param_UseDLCLaws==1) then {
 	a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind pushback "CUP_I_Van_Transport_ION";
 	};
@@ -395,13 +703,9 @@ a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind = [
 
 // Random array. Motorized search groups are sometimes sent to look for you. This array contains possible class definitions for the vehicles.
 a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
-	"CUP_B_MTLB_pk_Winter_CDF"
+    "CUP_B_BMP2_CDF"
 	,"CUP_B_BTR60_CDF"
-	,"CUP_B_BRDM2_CDF"
-	,"CUP_B_BMP2_CDF"
-	,"CUP_I_FENNEK_GMG_ION"
-	,"CUP_I_MATV_GMG_ION"
-	,"CUP_I_SUV_Armored_ION"];
+	,"CUP_B_MTLB_pk_Winter_CDF"];
 
 
 
@@ -425,6 +729,7 @@ a3e_arr_ComCenStaticWeapons = [
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
 	"CUP_B_UAZ_Unarmed_CDF"
+	,"CUP_B_UAZ_AGS30_CDF"
 	,"CUP_B_UAZ_MG_CDF"
 	,"CUP_B_UAZ_METIS_CDF"
 	,"CUP_B_UAZ_Open_CDF"
@@ -441,12 +746,11 @@ a3e_arr_ComCenParkedVehicles = [
 	,"CUP_B_Ural_ZU23_CDF"
 	,"CUP_I_SUV_ION"
 	,"CUP_I_SUV_Armored_ION"
-	,"CUP_I_SUV_Armored_ION"
-	,"CUP_I_MATV_GMG_ION"];
+	,"CUP_I_SUV_Armored_ION"];
 	if(Param_UseDLCApex==1) then {
-	a3e_arr_ComCenParkedVehicles pushback "CUP_I_LSV_02_Minigun_ION";
-	a3e_arr_ComCenParkedVehicles pushback "CUP_I_4WD_LMG_ION";
-	a3e_arr_ComCenParkedVehicles pushback "CUP_I_4WD_AT_ION";
+	a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_AT_ION";
+	a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_LMG_ION";
+	a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "CUP_I_4WD_unarmed_ION";
 	};
 	if(Param_UseDLCLaws==1) then {
 	a3e_arr_ComCenParkedVehicles pushback "CUP_I_Van_ammo_ION";
@@ -458,40 +762,211 @@ a3e_arr_ComCenParkedVehicles = [
 
 // Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
 a3e_arr_Escape_EnemyCivilianCarTypes = [
-	"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_03"
+	"CUP_C_Datsun"
+	,"CUP_C_Datsun"
+	,"CUP_C_Datsun"
 	,"CUP_C_Datsun"
 	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Datsun_4seat"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Golf4_camo_Civ"
+	,"CUP_C_Golf4_camodark_Civ"
+	,"CUP_C_Golf4_camodigital_Civ"
+	,"CUP_C_Golf4_crowe_Civ"
+	,"CUP_C_Golf4_kitty_Civ"
+	,"CUP_C_Golf4_reptile_Civ"
+	,"CUP_C_Golf4_whiteblood_Civ"
 	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
+	,"CUP_C_Octavia_CIV"
 	,"CUP_C_Skoda_Blue_CIV"
 	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Golf4_red_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_Skoda_Blue_CIV"
+	,"CUP_C_Skoda_Green_CIV"
+	,"CUP_C_Skoda_Red_CIV"
+	,"CUP_C_Skoda_White_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_S1203_Militia_CIV"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Covered"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Plain"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Datsun_Tubeframe"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Ikarus_Chernarus"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_C_Lada_White_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_LADA_LM_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
+	,"CUP_C_Lada_Red_CIV"
 	,"CUP_C_SUV_CIV"
-	,"C_Hatchback_01_F"
-	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
-	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
-	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
-	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"
-	,"C_Truck_02_covered_F"];
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_SUV_CIV"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+	,"CUP_C_Ural_Open_Civ_03"
+    ,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Open_Civ_01"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_Ural_Open_Civ_02"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_S1203_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_Lada_GreenTK_CIV"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_LR_Transport_CTK"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Open_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_V3S_Covered_TKC"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_SUV_TK"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Unarmed_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_UAZ_Open_TK_CIV"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Ural_Civ_01"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Blue_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Gray_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"
+	,"CUP_C_Volha_Limo_TKCIV"];
 	if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
 	};
@@ -506,11 +981,7 @@ a3e_arr_Escape_EnemyCivilianCarTypes = [
 
 // Random array. An ammo depot contains one static weapon of the followin types:
 a3e_arr_Escape_AmmoDepot_StaticWeaponClasses = [
-	"CUP_B_AGS_CDF"
-	,"CUP_B_DSHKM_CDF"
-	,"CUP_B_DSHkM_MiniTriPod_CDF"
-	,"CUP_B_SPG9_CDF"
-	,"CUP_B_ZU23_CDF"];
+	"CUP_B_DSHKM_CDF"];
 // An ammo depot have one parked and empty vehicle of the following possible types.
 a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
 
@@ -519,7 +990,6 @@ a3e_arr_O_attack_heli = [
 	"CUP_B_Mi24_D_Dynamic_CDF"];
 a3e_arr_O_transport_heli = [
 	"CUP_B_Mi17_CDF"
-	,"CUP_B_Mi17_medevac_CDF"
 	,"CUP_B_MI6T_CDF"];
 a3e_arr_O_pilots = [
 	"CUP_B_CDF_Pilot_SNW"];
@@ -541,84 +1011,67 @@ a3e_arr_I_pilots = [
 a3e_arr_AmmoDepotBasicWeapons = [];
 // CSAT weapons
 a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_hgun_Makarov", 50, 2, 5, ["CUP_8Rnd_9x18_Makarov_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKS", 10, 1, 2, ["CUP_30Rnd_762x39_AK47_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74M", 50, 2, 4, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74M_GL", 75, 2, 4, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_1Rnd_HE_GP25_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_PKM", 20, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_SVD_des", 10, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_SVD_des_ghillie_pso", 10, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKS", 25, 1, 2, ["CUP_30Rnd_762x39_AK47_M", "CUP_30Rnd_TE1_Green_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Red_Tracer_762x39_AK47_M", "CUP_30Rnd_TE1_Yellow_Tracer_762x39_AK47_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AKS74U", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_White_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_White_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK74_GL", 75, 2, 4, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_White_Tracer_545x39_AK_M", "CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M", "CUP_1Rnd_HE_GP25_M"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_SVD", 10, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 6];
 // non-CSAT weapons
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_M249_para", 50, 2, 4, ["CUP_200Rnd_TE4_Red_Tracer_556x45_M249"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A4_Base", 50, 1, 3, ["CUP_30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_M16A4_GL", 50, 1, 3, ["CUP_30Rnd_556x45_Stanag","CUP_1Rnd_HEDP_M203"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_XM8_Carbine", 10, 1, 2, ["CUP_30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_srifle_M14", 10, 1, 2, ["CUP_20Rnd_762x51_DMR"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL5062", 10, 1, 2, ["CUP_20Rnd_762x51_FNFAL_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL", 10, 1, 2, ["CUP_20Rnd_762x51_FNFAL_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_AK107_GL_kobra", 10, 1, 2, ["CUP_30Rnd_545x39_AK_M", "CUP_1Rnd_HE_GP25_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_Sa58RIS1", 10, 1, 2, ["CUP_30Rnd_Sa58_M"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_Sa58RIS2_gl", 10, 1, 2, ["CUP_30Rnd_Sa58_M","CUP_1Rnd_HE_M203"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_M60E4", 10, 1, 2, ["CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_sgun_M1014", 10, 1, 2, ["CUP_8Rnd_B_Beneli_74Slug","CUP_8Rnd_B_Beneli_74Pellets"], 10];
-a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_smg_MP5A5", 10, 1, 2, ["CUP_30Rnd_9x19_MP5"], 8];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_XM8_Carbine", 100, 3, 5, ["CUP_30Rnd_556x45_G36", "CUP_30Rnd_TE1_Red_Tracer_556x45_G36", "CUP_30Rnd_TE1_Green_Tracer_556x45_G36", "CUP_30Rnd_TE1_Yellow_Tracer_556x45_G36"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_XM8_Compact", 100, 3, 5, ["CUP_30Rnd_556x45_G36", "CUP_30Rnd_TE1_Red_Tracer_556x45_G36", "CUP_30Rnd_TE1_Green_Tracer_556x45_G36", "CUP_30Rnd_TE1_Yellow_Tracer_556x45_G36"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_XM8_Carbine_GL", 75, 3, 5, ["CUP_30Rnd_556x45_G36", "CUP_30Rnd_TE1_Red_Tracer_556x45_G36", "CUP_30Rnd_TE1_Green_Tracer_556x45_G36", "CUP_30Rnd_TE1_Yellow_Tracer_556x45_G36", "CUP_1Rnd_HEDP_M203"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL5062", 50, 1, 2, ["CUP_20Rnd_762x51_FNFAL_M"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_FNFAL", 50, 1, 2, ["CUP_20Rnd_762x51_FNFAL_M"], 4];
 
 
 // Weapons and ammo in the special weapons box
 a3e_arr_AmmoDepotSpecialWeapons = [];
 // CSAT weapons
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_SVD_des", 50, 2, 4, ["CUP_10Rnd_762x54_SVD_M"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_ksvk", 50, 2, 4, ["CUP_5Rnd_127x108_KSVK_M"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_VSSVintorez_pso", 10, 2, 4, ["CUP_20Rnd_9x39_SP5_VSS_M"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_Pecheneg", 50, 1, 3, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 4];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_UK59", 10, 1, 2, ["CUP_50Rnd_UK59_762x54R_Tracer"], 6];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_smg_bizon_snds", 50, 1, 2, ["CUP_64Rnd_9x19_Bizon_M"], 7];
-// non-CAST weapons
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_AS50", 10, 2, 4, ["CUP_5Rnd_127x99_as50_M"], 8];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_arifle_MG36", 30, 1, 2, ["CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag"], 6];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_SVD", 50, 2, 4, ["CUP_10Rnd_762x54_SVD_M"], 9];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_PKM", 50, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M", "CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Red_M", "CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Yellow_M"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_RPK74_45", 50, 1, 2, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M"], 4];
 
+// non-CAST weapons
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_xm8_SAW", 50, 2, 4, ["CUP_100Rnd_556x45_BetaCMag", "CUP_100Rnd_TE1_Red_Tracer_556x45_BetaCMag", "CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag", "CUP_100Rnd_TE1_Yellow_Tracer_556x45_BetaCMag"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_arifle_XM8_sharpshooter", 50, 2, 4, ["CUP_30Rnd_556x45_G36"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["CUP_lmg_PKM", 50, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M", "CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Red_M", "CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Yellow_M"], 4];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_ksvk", 10, 1, 2, ["CUP_5Rnd_127x108_KSVK_M"], 9];
 
 // Weapons and ammo in the launchers box
 a3e_arr_AmmoDepotLaunchers = [];
 // CSAT weapons
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 2, ["CUP_PG7V_M", "CUP_PG7VL_M", "CUP_PG7VR_M", "CUP_OG7_M"], 1];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG18", 50, 1, 3, ["CUP_RPG18_M"], 1];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 3, ["CUP_PG7V_M"], 3];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Metis", 50, 1, 3, ["CUP_AT13_M"], 2];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Igla", 50, 1, 2, ["CUP_Igla_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 2, ["CUP_PG7V_M", "CUP_PG7VM_M", "CUP_PG7VL_M", "CUP_PG7VR_M", "CUP_OG7_M", "CUP_TBG7V_M"], 2];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG18", 50, 3, 6, ["CUP_RPG18_M"], 0];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG7V", 50, 1, 3, ["CUP_PG7VL_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Igla", 50, 1, 2, ["CUP_Igla_M"], 0];
 // non-CSAT weapons
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M136", 20, 1, 3, ["CUP_M136_M"], 1];
-//a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_NLAW", 25, 1, 3, ["CUP_NLAW_M"], 2];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_M47", 20, 1, 3, ["CUP_Dragon_EP1_M"], 2];
-//a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_MAAWS_Scope", 40, 1, 2, ["CUP_MAAWS_HEAT_M"], 2];
-//a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_Javelin", 25, 1, 3, ["CUP_Javelin_M"], 2];
-a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_FIM92Stinger", 25, 1, 2, ["CUP_Stinger_M"], 3];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_RPG18", 50, 3, 6, ["CUP_RPG18_M"], 0];
+a3e_arr_AmmoDepotLaunchers pushback ["CUP_launch_FIM92Stinger", 50, 1, 2, ["CUP_Stinger_M"], 0];
 
 
 // Weapons and ammo in the ordnance box
 a3e_arr_AmmoDepotOrdnance = [];
 // General weapons
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["CUP_TimeBomb_M", "CUP_PipeBomb_M"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["APERSMine_Range_Mag", "APERSBoundingMine_Range_Mag", "APERSTripMine_Wire_Mag"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "CUP_Mine_M"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["Laserbatteries"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["APERSMine_Range_Mag", "APERSBoundingMine_Range_Mag", "APERSTripMine_Wire_Mag", "ClaymoreDirectionalMine_Remote_Mag"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["CUP_MineE_M"], 5];
 
 // Weapons and ammo in the vehicle box (the big one)
 // Some high volumes (mostly for immersion)
 a3e_arr_AmmoDepotVehicle = [];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_HandGrenade_M67"], 50];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_HandGrenade_RGO", "CUP_HandGrenade_RGD5"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["SmokeShell", "SmokeShellYellow", "SmokeShellRed", "SmokeShellGreen", "SmokeShellPurple", "SmokeShellBlue", "SmokeShellOrange"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_Smoke_M203","CUP_1Rnd_SmokeRed_M203","CUP_1Rnd_SmokeGreen_M203","CUP_1Rnd_SmokeYellow_M203"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["CUP_1Rnd_HE_GP25_M"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 25, 1, 1, ["CUP_1Rnd_StarCluster_White_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_1Rnd_StarCluster_Green_M203","CUP_1Rnd_StarFlare_White_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarFlare_Green_M203"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_FlareWhite_M203","CUP_FlareGreen_M203","CUP_FlareRed_M203","CUP_FlareYellow_M203"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["1Rnd_HE_Grenade_shell", "3Rnd_HE_Grenade_shell"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 100, 1, 1, ["CUP_1Rnd_StarCluster_White_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_1Rnd_StarCluster_Green_M203","CUP_1Rnd_StarFlare_White_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarFlare_Green_M203"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["CUP_1Rnd_HE_GP25_M", "CUP_1Rnd_SMOKE_GP25_M", "CUP_1Rnd_SmokeYellow_GP25_M", "CUP_1Rnd_SmokeGreen_GP25_M", "CUP_1Rnd_SmokeRed_GP25_M"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 100, 1, 1, ["CUP_IlumFlareGreen_GP25_M", "CUP_IlumFlareRed_GP25_M", "CUP_IlumFlareWhite_GP25_M"], 25];
 a3e_arr_AmmoDepotVehicleItems = [];
 a3e_arr_AmmoDepotVehicleItems pushback ["ToolKit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["Medikit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["FirstAidKit", 100, 10, 50, [], 0];
-a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_USMC_MOLLE_WDL"];
+a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_USMC_AssaultPack"];
 
 // Items
 
@@ -627,10 +1080,6 @@ a3e_arr_AmmoDepotVehicleBackpacks = ["CUP_B_USMC_MOLLE_WDL"];
 // Index 2: Minimum amount.
 // Index 3: Maximum amount.
 a3e_arr_AmmoDepotItems = [];
-a3e_arr_AmmoDepotItems pushback ["Laserdesignator", 10, 1, 2];
-if(Param_NoNightvision==0) then {
-	a3e_arr_AmmoDepotItems pushback ["NVGoggles", 10, 1, 3];
-};
 a3e_arr_AmmoDepotItems pushback ["Rangefinder", 10, 1, 2];
 a3e_arr_AmmoDepotItems pushback ["Binocular", 50, 2, 3, [], 0];
 a3e_arr_AmmoDepotItems pushback ["ItemCompass", 50, 1, 3];
@@ -638,58 +1087,23 @@ a3e_arr_AmmoDepotItems pushback ["ItemGPS", 10, 1, 2];
 a3e_arr_AmmoDepotItems pushback ["ItemMap", 50, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["ItemRadio", 50, 1, 10];
 a3e_arr_AmmoDepotItems pushback ["ItemWatch", 50, 1, 10];
-a3e_arr_AmmoDepotItems pushback ["CUP_acc_ANPEQ_15", 50, 1, 5];
 a3e_arr_AmmoDepotItems pushback ["CUP_acc_Flashlight", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_snds_M16", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_Bizon", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_PBS4", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_acc_XM8_light_module", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_snds_XM8", 10, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_PB6P9", 10, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_muzzle_PBS4", 10, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["CUP_optic_Kobra", 20, 1, 3];
 a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1", 20, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3", 20, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PechenegScope", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_Eotech533", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM4", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_ACOG", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_RCO", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_CompM2_Black", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_CQ_T", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_ELCAN_SpecterDR", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_SB_11_4x20_PM", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_ZDDot", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_MRad", 20, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_TrijiconRx01_black", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_SB_3_12x50_PMII", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_HoloBlack", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_HoloWdl", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldM3LR", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_LeupoldMk4_10x40_LRT_Woodland", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_Kobra", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PechenegScope", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1_open", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1_AK", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_1_AK_open", 20, 1, 3];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3", 10, 1, 1];
+a3e_arr_AmmoDepotItems pushback ["CUP_optic_PSO_3_open", 10, 1, 1];
 if(Param_NoNightvision==0) then {
-	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PAS_13c1", 10, 1, 3];
-	a3e_arr_AmmoDepotItems pushback ["CUP_optic_AN_PVS_10", 10, 1, 3];
-	a3e_arr_AmmoDepotItems pushback ["CUP_optic_CWS", 10, 1, 3];
+    a3e_arr_AmmoDepotItems pushback ["CUP_NVG_PVS7", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_GOSHAWK", 10, 1, 3];
 	a3e_arr_AmmoDepotItems pushback ["CUP_optic_NSPU", 10, 1, 3];
 };
-a3e_arr_AmmoDepotItems pushback ["O_UavTerminal", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_DMS", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_Yorris", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_LRPS", 10, 1, 3];
-a3e_arr_AmmoDepotItems pushback ["optic_AMS", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["optic_KHS_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_01_F_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_02_F_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_03_F_blk", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_01_F_mtp", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_02_F_hex", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["bipod_03_F_oli", 10, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["CUP_bipod_VLTOR_Modpod", 20, 1, 2];
-a3e_arr_AmmoDepotItems pushback ["CUP_bipod_Harris_1A2_L", 10, 1, 2];
 
 
 // Weapons that may show up in civilian cars
@@ -698,26 +1112,27 @@ a3e_arr_AmmoDepotItems pushback ["CUP_bipod_Harris_1A2_L", 10, 1, 2];
 // Index 1: Magazine classname.
 // Index 2: Number of magazines.
 a3e_arr_CivilianCarWeapons = [];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AK47_Early", "CUP_30Rnd_762x39_AK47_M", 5];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_PB6P9_snds", "CUP_8Rnd_9x18_MakarovSD_M", 5];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL_railed", "CUP_20Rnd_762x51_FNFAL_M", 7];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Pellets", 11];
-a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_HE", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A2_Holo_Laser", "CUP_30Rnd_556x45_Stanag", 6];
+a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL", "CUP_20Rnd_762x51_FNFAL_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_M14", "CUP_20Rnd_762x51_DMR", 8];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_MicroUzi_snds", "CUP_30Rnd_9x19_UZI", 4];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_Saiga12K", "CUP_8Rnd_B_Saiga12_74Pellets_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_Saiga12K", "CUP_20Rnd_B_Saiga12_74Pellets_M", 4];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_Saiga12K", "CUP_8Rnd_B_Saiga12_74Slug_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_Saiga12K", "CUP_20Rnd_B_Saiga12_74Slug_M", 4];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_UK59", "CUP_50Rnd_UK59_762x54R_Tracer", 6];
 a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_AKS_Gold", "CUP_30Rnd_762x39_AK47_M", 8];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ750_SOS_bipod", "CUP_10Rnd_762x51_CZ750", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_ksvk_PSO3", "CUP_5Rnd_127x108_KSVK_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 1];
+a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_SA61","CUP_20Rnd_B_765x17_Ball_M", 7];
+a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_SA61","CUP_50Rnd_B_765x17_Ball_M", 3];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Medikit", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Toolkit", objNull, 0];
 a3e_arr_CivilianCarWeapons pushback ["Binocular", objNull, 0];
-a3e_arr_CivilianCarWeapons pushback [objNull, "SatchelCharge_Remote_Mag", 2];
+a3e_arr_CivilianCarWeapons pushback [objNull, "CUP_PipeBomb_M", 2];
 a3e_arr_CivilianCarWeapons pushback [objNull, "HandGrenade", 5];
 a3e_arr_CivilianCarWeapons pushback [objNull, "SmokeShell", 5];
 
@@ -725,56 +1140,20 @@ a3e_arr_CivilianCarWeapons pushback [objNull, "SmokeShell", 5];
 // Here is a list of scopes:
 a3e_arr_Scopes = [
 	"CUP_optic_Kobra"
-	,"CUP_optic_PSO_1"
-	,"CUP_optic_PSO_3"
-	,"CUP_optic_PechenegScope"
-	,"CUP_optic_SB_3_12x50_PMII"
-	,"CUP_optic_LeupoldMk4"
-	,"CUP_optic_HoloWdl"
-	,"CUP_optic_HoloWdl"
-	,"CUP_optic_HoloWdl"
-	,"CUP_optic_Eotech533"
-	,"CUP_optic_Eotech533Grey"
-	,"CUP_optic_CompM4"
-	,"CUP_optic_SUSAT"
-	,"CUP_optic_ACOG"
-	,"CUP_optic_RCO"
-	,"CUP_optic_RCO"
-	,"CUP_optic_ElcanM145"
-	,"CUP_optic_ELCAN_SpecterDR"
-	,"CUP_optic_LeupoldMk4_CQ_T"
-	,"CUP_optic_ZDDot"];
+	,"CUP_optic_PSO_1_AK"
+	,"CUP_optic_PSO_1_AK_open"];
 a3e_arr_Scopes_SMG = [
-	"CUP_optic_Kobra"
-	,"CUP_optic_Eotech533"
-	,"CUP_optic_ZDDot"];
+	"CUP_optic_Kobra"];
 a3e_arr_Scopes_Sniper = [
 	"CUP_optic_PSO_1"
-	,"CUP_optic_PSO_3"
-	,"CUP_optic_LeupoldMk4"
-	,"CUP_optic_SB_3_12x50_PMII"
-	,"CUP_optic_LeupoldMk4_10x40_LRT_Woodland"];
+	,"CUP_optic_PSO_3"];
 a3e_arr_NightScopes = [
-	"CUP_optic_NSPU"
-	,"CUP_optic_AN_PVS_10"
-	,"CUP_optic_AN_PVS_4"];
+	"CUP_optic_NSPU"];
 a3e_arr_TWSScopes = [
-	"CUP_optic_GOSHAWK"
-	,"CUP_optic_AN_PAS_13c2"
-	,"CUP_optic_AN_PAS_13c1"];
+	"CUP_optic_GOSHAWK"];
 
 // Here is a list of bipods, might get randomly added to enemy patrols:
-a3e_arr_Bipods = [
-	"CUP_bipod_VLTOR_Modpod"
-	,"CUP_bipod_Harris_1A2_L"
-	,"bipod_01_F_snd"
-	,"bipod_01_F_blk"
-	,"bipod_01_F_mtp"
-	,"bipod_02_F_blk"
-	,"bipod_02_F_tan"
-	,"bipod_02_F_hex"
-	,"bipod_03_F_blk"
-	,"bipod_03_F_oli"];
+a3e_arr_Bipods = [];
 
 
 //////////////////////////////////////////////////////////////////
@@ -884,7 +1263,6 @@ a3e_arr_MortarSite = [
 //////////////////////////////////////////////////////////////////
 a3e_arr_CASplane = [
 	"CUP_B_Su25_Dyn_CDF"
-	,"CUP_B_SU34_CDF"
 	,"CUP_B_SU34_CDF"];
 
 //////////////////////////////////////////////////////////////////
@@ -901,30 +1279,34 @@ a3e_arr_CASplane = [
 a3e_arr_CrashSiteWrecks = [
 	"Mi8Wreck"];
 a3e_arr_CrashSiteCrew = [
-	"CUP_O_RU_Pilot"];
+	"CUP_O_RU_Pilot_EMR"];
 a3e_arr_CrashSiteWrecksCar = [
 	"Land_Wreck_BMP2_F"
 	,"Land_Wreck_BRDM2_F"
-	,"T72Wreck"];
+	,"T72Wreck"
+	,"BDRMWreck"];
 a3e_arr_CrashSiteCrewCar = [
-	"CUP_O_RU_Crew_VDV"
-	,"CUP_O_RU_Soldier_Saiga_VDV"];
+	"CUP_O_RU_Crew_EMR"];
 // Weapons and ammo in crash site box
 a3e_arr_CrashSiteWeapons = [];
+a3e_arr_CrashSiteWeapons pushback ["CUP_hgun_PB6P9", 50, 2, 5, ["CUP_8Rnd_9x18_Makarov_M", "CUP_8Rnd_9x18_MakarovSD_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74m", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
 a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK74M_GL", 50, 2, 5, ["CUP_30Rnd_545x39_AK_M","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M","CUP_1Rnd_HE_GP25_M"], 4];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AKS74U", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M", "CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M"], 4];
 a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG7V", 10, 1, 2, ["CUP_PG7V_M"], 2];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AK107", 100, 3, 5, ["CUP_30Rnd_545x39_AK_M"], 4];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_RPK74_45", 10, 1, 2, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M"], 5];
-a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_AKS", 75, 2, 4, ["CUP_30Rnd_762x39_AK47_M"], 6];
-a3e_arr_CrashSiteWeapons pushback ["CUP_SVD_camo_g_half", 20, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 8];
-a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_VSSVintorez", 10, 1, 2, ["CUP_20Rnd_9x39_SP5_VSS_M"], 8];
-a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_PKM", 10, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG7V", 10, 1, 2, ["CUP_PG7V_M", "CUP_PG7VM_M", "CUP_PG7VL_M", "CUP_PG7VR_M", "CUP_OG7_M", "CUP_TBG7V_M"], 2];
+a3e_arr_CrashSiteWeapons pushback ["CUP_launch_RPG18", 10, 2, 4, ["CUP_RPG18_M"], 0];
+a3e_arr_CrashSiteWeapons pushback ["CUP_arifle_RPK74_45", 25, 1, 2, ["CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M"], 5];
+a3e_arr_CrashSiteWeapons pushback ["CUP_SVD", 25, 1, 2, ["CUP_10Rnd_762x54_SVD_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_srifle_VSSVintorez_pso", 10, 1, 2, ["CUP_20Rnd_9x39_SP5_VSS_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_smg_bizon", 10, 1, 2, ["CUP_64Rnd_9x19_Bizon_M"], 8];
+a3e_arr_CrashSiteWeapons pushback ["CUP_lmg_Pecheneg", 25, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 6];
+a3e_arr_CrashSiteWeapons pushback ["CUP_sgun_Saiga12K", 10, 1, 2, ["CUP_8Rnd_B_Saiga12_74Pellets_M", "CUP_8Rnd_B_Saiga12_74Slug_M"], 6];
 // Attachments and other items in crash site box
 a3e_arr_CrashSiteItems = [];
 a3e_arr_CrashSiteItems pushback ["CUP_muzzle_PBS4", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["CUP_muzzle_Bizon", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["CUP_optic_Kobra", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_Kobra", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_3", 10, 1, 3];
-a3e_arr_CrashSiteItems pushback ["CUP_optic_PechenegScope", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1_AK", 50, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PSO_1", 50, 1, 3];
+a3e_arr_CrashSiteItems pushback ["CUP_optic_PechenegScope", 25, 1, 3];

--- a/Mods/Vanilla US/UnitClasses.sqf
+++ b/Mods/Vanilla US/UnitClasses.sqf
@@ -29,34 +29,63 @@ a3e_arr_Escape_StartPositionGuardTypes = [
 
 // Prison backpack secondary weapon (and corresponding magazine type).
 a3e_arr_PrisonBackpackWeapons = [];
+//Pistols
 a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_F","16Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_PDW2000_F","30Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_snds_F","9Rnd_45ACP_Mag"];
 a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_snds_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_snds_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_01_F","11Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_01_MRD_F","11Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_01_snds_F","11Rnd_45ACP_Mag"];
 a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_02_F","6Rnd_45ACP_Cylinder"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_snds_F","30Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_snds_F","30Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_02_F","6Rnd_45ACP_Cylinder"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_02_Yorris_F","6Rnd_45ACP_Cylinder"];
+//SMGs
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_PDW2000_F","30Rnd_9x21_Mag"];
 
 // Random array. Civilian vehicle classes for ambient traffic.
 a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 	"C_Hatchback_01_F"
-	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
-	,"C_SUV_01_F"
+	,"C_Hatchback_01_F"
+	,"C_Hatchback_01_F"
+	,"C_Hatchback_01_F"
 	,"C_Hatchback_01_F"
 	,"C_Hatchback_01_sport_F"
+	,"C_Hatchback_01_sport_F"
+	,"C_Offroad_01_F"
+	,"C_Offroad_01_F"
+	,"C_Offroad_01_F"
+	,"C_Offroad_01_F"
 	,"C_Offroad_01_F"
 	,"C_Quadbike_01_F"
+	,"C_Quadbike_01_F"
+	,"C_Quadbike_01_F"
 	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
 	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
+	,"C_Van_01_transport_F"
 	,"C_Truck_02_covered_F"
+	,"C_Truck_02_covered_F"
+	,"C_Truck_02_transport_F"
+	,"C_Truck_02_transport_F"
+	//Supply Trucks
+	,"C_Van_01_fuel_F"
+	,"C_Van_01_box_F"
 	,"C_Offroad_01_repair_F"
 	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"];
+	,"C_Truck_02_box_F"];
 	if(Param_UseDLCApex==1) then {
 	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Offroad_02_unarmed_F";
 	};
@@ -73,36 +102,83 @@ a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 switch (_enemyFrequency) do {
     case 1: {//Few (1-3)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"B_MRAP_01_F"
+		//Unarmed Cars/UAVs  2 sets
+		"B_MRAP_01_F"  //1
 		,"B_MRAP_01_F"
-		,"B_MRAP_01_gmg_F"
-		,"B_MRAP_01_gmg_F"
-		,"B_MRAP_01_hmg_F"
-		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
 		,"B_Quadbike_01_F"
 		,"B_Quadbike_01_F"
 		,"B_Quadbike_01_F"
-		,"B_UGV_01_rcws_F"
+		,"B_Truck_01_mover_F"
+		,"B_Truck_01_box_F"
+		,"B_Truck_01_cargo_F"
+		,"B_Truck_01_flatbed_F"
 		,"B_Truck_01_covered_F"
 		,"B_Truck_01_transport_F"
-		,"B_Truck_01_ammo_F"
-		,"B_Truck_01_box_F"
-		,"B_Truck_01_fuel_F"
 		,"B_Truck_01_medical_F"
-		,"B_Truck_01_Repair_F"
+		,"B_UGV_01_F"
+		,"B_MRAP_01_F"  //2
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_Quadbike_01_F"
+		,"B_Quadbike_01_F"
+		,"B_Quadbike_01_F"
 		,"B_Truck_01_mover_F"
-		,"B_APC_Wheeled_01_cannon_F"
-		,"B_APC_Wheeled_01_cannon_F"
+		,"B_Truck_01_box_F"
+		,"B_Truck_01_cargo_F"
+		,"B_Truck_01_flatbed_F"
+		,"B_Truck_01_covered_F"
+		,"B_Truck_01_transport_F"
+		,"B_Truck_01_medical_F"
+		,"B_UGV_01_F"
+		//Supply Trucks  1 set
+		,"B_Truck_01_ammo_F"
+		,"B_Truck_01_fuel_F"
+		,"B_Truck_01_Repair_F"
+		,"B_Truck_01_ammo_F"
+		,"B_Truck_01_fuel_F"
+		,"B_Truck_01_Repair_F"		
+		//Armed UAVs  1 set
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		//MRAPs  1 set
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		//Heavily Armed APCs or AA
 		,"B_APC_Tracked_01_AA_F"
+		,"B_APC_Wheeled_01_cannon_F"
 		,"B_APC_Tracked_01_CRV_F"
 		,"B_APC_Tracked_01_rcws_F"
+		//Artillery
 		,"B_MBT_01_arty_F"
 		,"B_MBT_01_mlrs_F"
+		//Tanks
 		,"B_MBT_01_cannon_F"
 		,"B_MBT_01_TUSK_F"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
 		};
 		if(Param_UseDLCTanks==1) then {
@@ -110,172 +186,474 @@ switch (_enemyFrequency) do {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_up_cannon_F";
 		};
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"I_G_Offroad_01_repair_F"
+		//Unarmed Cars/UAVs  3 sets
+		"I_Quadbike_01_F"  //1
 		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_AT_F"
-		,"I_G_Offroad_01_AT_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
 		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //2
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //3
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		//Supply Trucks  1 set
+		,"I_Truck_02_ammo_F"
+		,"I_Truck_02_fuel_F"
+		,"I_Truck_02_box_F"
+		,"I_G_Van_01_fuel_F"
+		,"I_G_Offroad_01_repair_F"
+		//Armed Cars  1 set
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		//Armed UAVs  1 set
 		,"I_UGV_01_rcws_F"
+		,"I_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		//Heavily Armed APCs or AA  1 set
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		//Artillery  1 set
 		,"I_Truck_02_MRL_F"
-		,"I_MBT_03_cannon_F"
-		,"I_MBT_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"];
+		//Tanks  1 set
+		,"I_MBT_03_cannon_F"];
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
 		};
+		if(Param_UseDLCLaws==1) then {
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+	    };
     };
     case 2: {//Some (4-6)
-        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"B_MRAP_01_F"
+	    a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
+		//Unarmed Cars/UAVs  2 sets
+		"B_MRAP_01_F"  //1
 		,"B_MRAP_01_F"
-		,"B_MRAP_01_gmg_F"
-		,"B_MRAP_01_gmg_F"
-		,"B_MRAP_01_hmg_F"
-		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
 		,"B_Quadbike_01_F"
 		,"B_Quadbike_01_F"
 		,"B_Quadbike_01_F"
-		,"B_UGV_01_rcws_F"
+		,"B_Truck_01_mover_F"
+		,"B_Truck_01_box_F"
+		,"B_Truck_01_cargo_F"
+		,"B_Truck_01_flatbed_F"
 		,"B_Truck_01_covered_F"
 		,"B_Truck_01_transport_F"
-		,"B_Truck_01_ammo_F"
-		,"B_Truck_01_box_F"
-		,"B_Truck_01_fuel_F"
 		,"B_Truck_01_medical_F"
-		,"B_Truck_01_Repair_F"
+		,"B_UGV_01_F"
+		,"B_MRAP_01_F"  //2
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_Quadbike_01_F"
+		,"B_Quadbike_01_F"
+		,"B_Quadbike_01_F"
 		,"B_Truck_01_mover_F"
-		,"B_APC_Wheeled_01_cannon_F"
-		,"B_APC_Wheeled_01_cannon_F"
+		,"B_Truck_01_box_F"
+		,"B_Truck_01_cargo_F"
+		,"B_Truck_01_flatbed_F"
+		,"B_Truck_01_covered_F"
+		,"B_Truck_01_transport_F"
+		,"B_Truck_01_medical_F"
+		,"B_UGV_01_F"
+		//Supply Trucks  1 set
+		,"B_Truck_01_ammo_F"
+		,"B_Truck_01_fuel_F"
+		,"B_Truck_01_Repair_F"
+		,"B_Truck_01_ammo_F"
+		,"B_Truck_01_fuel_F"
+		,"B_Truck_01_Repair_F"		
+		//Armed UAVs  2 sets
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		//MRAPs  2 sets
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		//Heavily Armed APCs or AA
 		,"B_APC_Tracked_01_AA_F"
+		,"B_APC_Wheeled_01_cannon_F"
 		,"B_APC_Tracked_01_CRV_F"
 		,"B_APC_Tracked_01_rcws_F"
+		//Artillery
 		,"B_MBT_01_arty_F"
 		,"B_MBT_01_mlrs_F"
+		//Tanks
 		,"B_MBT_01_cannon_F"
 		,"B_MBT_01_TUSK_F"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
 		};
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_cannon_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_up_cannon_F";
 		};
-        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"I_G_Offroad_01_repair_F"
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
+		//Unarmed Cars/UAVs  3 sets
+		"I_Quadbike_01_F"  //1
 		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_AT_F"
-		,"I_G_Offroad_01_AT_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
 		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //2
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //3
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		//Supply Trucks  1 set
+		,"I_Truck_02_ammo_F"
+		,"I_Truck_02_fuel_F"
+		,"I_Truck_02_box_F"
+		,"I_G_Van_01_fuel_F"
+		,"I_G_Offroad_01_repair_F"
+		//Armed Cars  2 sets
+		,"I_G_Offroad_01_AT_F"  //1
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_AT_F"  //2
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		//Armed UAVs  2 sets
+		,"I_UGV_01_rcws_F"  //1
 		,"I_UGV_01_rcws_F"
+		,"I_UGV_01_rcws_F"  //2
+		,"I_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		//Heavily Armed APCs or AA  1 set
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		//Artillery  1 set
 		,"I_Truck_02_MRL_F"
-		,"I_MBT_03_cannon_F"
-		,"I_MBT_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"];
+		//Tanks  1 set
+		,"I_MBT_03_cannon_F"];
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
 		};
+		if(Param_UseDLCLaws==1) then {
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+	    };
     };
     default {//A lot (7-8)
-        a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"B_MRAP_01_F"
+	    a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
+		//Unarmed Cars/UAVs  2 sets
+		"B_MRAP_01_F"  //1
 		,"B_MRAP_01_F"
-		,"B_MRAP_01_gmg_F"
-		,"B_MRAP_01_gmg_F"
-		,"B_MRAP_01_hmg_F"
-		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
 		,"B_Quadbike_01_F"
 		,"B_Quadbike_01_F"
 		,"B_Quadbike_01_F"
-		,"B_UGV_01_rcws_F"
+		,"B_Truck_01_mover_F"
+		,"B_Truck_01_box_F"
+		,"B_Truck_01_cargo_F"
+		,"B_Truck_01_flatbed_F"
 		,"B_Truck_01_covered_F"
 		,"B_Truck_01_transport_F"
-		,"B_Truck_01_ammo_F"
-		,"B_Truck_01_box_F"
-		,"B_Truck_01_fuel_F"
 		,"B_Truck_01_medical_F"
-		,"B_Truck_01_Repair_F"
+		,"B_UGV_01_F"
+		,"B_MRAP_01_F"  //2
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_MRAP_01_F"
+		,"B_Quadbike_01_F"
+		,"B_Quadbike_01_F"
+		,"B_Quadbike_01_F"
 		,"B_Truck_01_mover_F"
-		,"B_APC_Wheeled_01_cannon_F"
-		,"B_APC_Wheeled_01_cannon_F"
+		,"B_Truck_01_box_F"
+		,"B_Truck_01_cargo_F"
+		,"B_Truck_01_flatbed_F"
+		,"B_Truck_01_covered_F"
+		,"B_Truck_01_transport_F"
+		,"B_Truck_01_medical_F"
+		,"B_UGV_01_F"
+		//Supply Trucks  1 set
+		,"B_Truck_01_ammo_F"
+		,"B_Truck_01_fuel_F"
+		,"B_Truck_01_Repair_F"
+		,"B_Truck_01_ammo_F"
+		,"B_Truck_01_fuel_F"
+		,"B_Truck_01_Repair_F"		
+		//Armed UAVs  2 sets
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		,"B_UGV_01_rcws_F"
+		//MRAPs  2 sets
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_gmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		,"B_MRAP_01_hmg_F"
+		//Heavily Armed APCs or AA  2 sets
 		,"B_APC_Tracked_01_AA_F"
+		,"B_APC_Wheeled_01_cannon_F"
 		,"B_APC_Tracked_01_CRV_F"
 		,"B_APC_Tracked_01_rcws_F"
+		,"B_APC_Tracked_01_AA_F"
+		,"B_APC_Wheeled_01_cannon_F"
+		,"B_APC_Tracked_01_CRV_F"
+		,"B_APC_Tracked_01_rcws_F"
+		//Artillery
 		,"B_MBT_01_arty_F"
-		,"B_MBT_01_mlrs_F"
-		,"B_MBT_01_cannon_F"
+		//Tanks  2 sets
+		,"B_MBT_01_cannon_F"  //1
+		,"B_MBT_01_TUSK_F"
+		,"B_MBT_01_cannon_F"  //2
 		,"B_MBT_01_TUSK_F"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_unarmed_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_LSV_01_AT_F";
 		};
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_cannon_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_up_cannon_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_cannon_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "B_AFV_Wheeled_01_up_cannon_F";
 		};
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"I_G_Offroad_01_repair_F"
+		//Unarmed Cars/UAVs  3 sets
+		"I_Quadbike_01_F"  //1
 		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_AT_F"
-		,"I_G_Offroad_01_AT_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
 		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //2
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //3
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		//Supply Trucks  1 set
+		,"I_Truck_02_ammo_F"
+		,"I_Truck_02_fuel_F"
+		,"I_Truck_02_box_F"
+		,"I_G_Van_01_fuel_F"
+		,"I_G_Offroad_01_repair_F"
+		//Armed Cars  2 sets
+		,"I_G_Offroad_01_AT_F"  //1
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_AT_F"  //2
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		//Armed UAVs  2 sets
+		,"I_UGV_01_rcws_F"  //1
 		,"I_UGV_01_rcws_F"
+		,"I_UGV_01_rcws_F"  //2
+		,"I_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		//Heavily Armed APCs or AA  2 sets
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		//Artillery  1 set
 		,"I_Truck_02_MRL_F"
+		//Tanks  2 sets
 		,"I_MBT_03_cannon_F"
-		,"I_MBT_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"];
+		,"I_MBT_03_cannon_F"];
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
 		};
+		if(Param_UseDLCLaws==1) then {
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+	    };
     };
 };
 
 // Random array. General infantry types. E.g. village patrols, ambient infantry, etc. (for ammo depot guards and communication center guards see further down in this file at fn_InitGuardedLocations)
 a3e_arr_Escape_InfantryTypes = [
 	"B_engineer_F"
-	,"B_engineer_F"
-	,"B_engineer_F"
 	,"B_medic_F"
 	,"B_medic_F"
 	,"B_medic_F"
@@ -290,10 +668,12 @@ a3e_arr_Escape_InfantryTypes = [
 	,"B_soldier_AT_F"
 	,"B_soldier_AT_F"
 	,"B_soldier_exp_F"
-	,"B_soldier_exp_F"
 	,"B_Soldier_F"
 	,"B_Soldier_F"
 	,"B_Soldier_F"
+	,"B_Soldier_GL_F"
+	,"B_Soldier_GL_F"
+	,"B_Soldier_GL_F"
 	,"B_Soldier_GL_F"
 	,"B_Soldier_GL_F"
 	,"B_Soldier_GL_F"
@@ -307,7 +687,6 @@ a3e_arr_Escape_InfantryTypes = [
 	,"B_soldier_M_F"
 	,"B_soldier_repair_F"
 	,"B_soldier_repair_F"
-	,"B_officer_F"
 	,"B_officer_F"
 	,"B_soldier_UAV_F"
 	,"B_soldier_UAV_F"
@@ -321,6 +700,7 @@ a3e_arr_Escape_InfantryTypes = [
 	,"B_support_Mort_F"
 	,"B_Soldier_SL_F"
 	,"B_Soldier_TL_F"
+	,"B_soldier_LAT2_F"
 	,"B_soldier_LAT2_F"];
 	if(Param_UseDLCMarksmen==1) then {
 		a3e_arr_Escape_InfantryTypes pushback "B_HeavyGunner_F";
@@ -333,8 +713,6 @@ a3e_arr_Escape_InfantryTypes = [
 	};
 a3e_arr_Escape_InfantryTypes_Ind = [
 	"I_engineer_F"
-	,"I_engineer_F"
-	,"I_engineer_F"
 	,"I_medic_F"
 	,"I_medic_F"
 	,"I_medic_F"
@@ -348,8 +726,8 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	,"I_Soldier_AR_F"
 	,"I_Soldier_AT_F"
 	,"I_Soldier_exp_F"
-	,"I_Soldier_exp_F"
-	,"I_Soldier_exp_F"
+	,"I_soldier_F"
+	,"I_soldier_F"
 	,"I_soldier_F"
 	,"I_soldier_F"
 	,"I_soldier_F"
@@ -365,8 +743,6 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	,"I_Soldier_M_F"
 	,"I_Soldier_M_F"
 	,"I_Soldier_repair_F"
-	,"I_Soldier_repair_F"
-	,"I_officer_F"
 	,"I_officer_F"
 	,"I_soldier_UAV_F"
 	,"I_soldier_UAV_F"
@@ -381,10 +757,9 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	,"I_Soldier_LAT2_F"
 	,"I_Soldier_LAT2_F"
 	,"I_Spotter_F"
-	,"I_Sniper_F"];
-	if(Param_UseDLCMarksmen==1) then {
-		a3e_arr_Escape_InfantryTypes_Ind pushback "I_ghillie_ard_F";
-	};
+	,"I_Sniper_F"
+	,"I_Soldier_SL_F"
+	,"I_Soldier_TL_F"];
 	if(Param_UseDLCLaws==1) then {
 		a3e_arr_Escape_InfantryTypes_Ind pushback "I_soldier_mine_F";
 		a3e_arr_Escape_InfantryTypes_Ind pushback "I_soldier_UAV_06_F";
@@ -402,8 +777,7 @@ a3e_arr_recon_InfantryTypes = [
 		a3e_arr_recon_InfantryTypes pushback "B_Recon_Sharpshooter_F";
 	};
 a3e_arr_recon_I_InfantryTypes = [
-	"I_G_officer_F"
-	,"I_G_Soldier_A_F"
+	"I_G_Soldier_A_F"
 	,"I_G_Soldier_LAT_F"
 	,"I_G_Soldier_M_F"
 	,"I_G_Soldier_GL_F"
@@ -416,32 +790,22 @@ a3e_arr_recon_I_InfantryTypes = [
 	,"I_G_Soldier_lite_F"
 	,"I_G_Soldier_F"
 	,"I_G_Soldier_LAT2_F"];
-	if(Param_UseDLCMarksmen==1) then {
-		a3e_arr_recon_I_InfantryTypes pushback "I_G_Sharpshooter_F";
-	};
 
 // Random array. A roadblock has a manned vehicle. This array contains possible manned vehicles (can be of any kind, like cars, armored and statics).
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
 	"B_MRAP_01_hmg_F"
 	,"B_MRAP_01_hmg_F"
 	,"B_MRAP_01_gmg_F"
-	,"B_UGV_01_rcws_F"
-	,"B_HMG_01_high_F"
-	,"B_static_AT_F"];
-	if(Param_UseDLCApex==1) then {
-		a3e_arr_Escape_RoadBlock_MannedVehicleTypes pushback "B_LSV_01_armed_F";
-		a3e_arr_Escape_RoadBlock_MannedVehicleTypes pushback "B_LSV_01_AT_F";
-	};
+	,"B_UGV_01_rcws_F"];
+	
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind = [
-	"I_G_Offroad_01_armed_F"
-	,"I_G_Offroad_01_AT_F"
+	"I_MRAP_03_hmg_F"
 	,"I_MRAP_03_hmg_F"
-	,"I_HMG_01_high_f"
-	,"I_static_AT_F"
-	,"I_G_Offroad_01_F"];
+	,"I_MRAP_03_gmg_F"
+	,"I_UGV_01_rcws_F"];
 	if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "I_LT_01_AT_F";
-		a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "I_LT_01_cannon_F";
+		a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "I_LT_01_cannon_F";	
 	};
 
 // Random array. Vehicle classes (preferrably trucks) transporting enemy reinforcements.
@@ -459,11 +823,7 @@ a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind = [
 a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 	"B_APC_Wheeled_01_cannon_F"
 	,"B_APC_Wheeled_01_cannon_F"
-	,"B_APC_Tracked_01_rcws_F"
-	,"B_MRAP_01_hmg_F"];
-	if(Param_UseDLCTanks==1) then {
-		a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses pushback "I_LT_01_cannon_F";
-	};
+	,"B_APC_Tracked_01_rcws_F"];
 
 
 // A communication center is guarded by vehicles depending on variable _enemyFrequency. 1 = a random light armor. 2 = a random heavy armor. 3 = a random 
@@ -473,12 +833,10 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 a3e_arr_ComCenDefence_lightArmorClasses = [
 	"B_MRAP_01_gmg_F"
 	,"B_MRAP_01_hmg_F"
-	,"B_APC_Wheeled_01_cannon_F"
-	,"B_MRAP_01_gmg_F"];
+	,"B_APC_Wheeled_01_cannon_F"];
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
-	"B_MBT_01_cannon_F"
-	,"B_MBT_01_TUSK_F"
+	"B_MBT_01_TUSK_F"
 	,"B_APC_Tracked_01_AA_F"];
 	if(Param_UseDLCTanks==1) then {
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "B_AFV_Wheeled_01_up_cannon_F";
@@ -492,16 +850,13 @@ a3e_arr_ComCenStaticWeapons = [
 	,"B_GMG_01_high_F"];
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
-	"I_G_Offroad_01_repair_F"
+	"B_MRAP_01_F"
 	,"B_MRAP_01_F"
+	,"B_Quadbike_01_F"
+	,"B_Quadbike_01_F"
+	,"B_Quadbike_01_F"
 	,"B_MRAP_01_gmg_F"
 	,"B_MRAP_01_hmg_F"
-	,"B_MRAP_01_F"
-	,"I_G_Offroad_01_armed_F"
-	,"I_G_Offroad_01_AT_F"
-	,"I_MRAP_03_hmg_F"
-	,"I_MRAP_03_gmg_F"
-	,"I_G_Offroad_01_F"
 	,"B_Truck_01_transport_F"
 	,"B_Truck_01_covered_F"
 	,"B_Truck_01_ammo_F"
@@ -509,25 +864,21 @@ a3e_arr_ComCenParkedVehicles = [
 	,"B_Truck_01_medical_F"
 	,"B_Truck_01_Repair_F"
 	,"B_Truck_01_box_F"
-	,"B_Truck_01_mover_F"];
+	,"B_Truck_01_mover_F"
+	,"B_Truck_01_cargo_F"
+	,"B_Truck_01_flatbed_F"
+	,"B_UGV_01_rcws_F"];
 	if(Param_UseDLCApex==1) then {
 		a3e_arr_ComCenParkedVehicles pushback "B_LSV_01_unarmed_F";
 		a3e_arr_ComCenParkedVehicles pushback "B_LSV_01_armed_F";
 		a3e_arr_ComCenParkedVehicles pushback "B_LSV_01_AT_F";
 	};
+	
 // Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
 a3e_arr_Escape_EnemyCivilianCarTypes = [
 	"C_Hatchback_01_F"
 	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
 	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
-	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
-	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"
 	,"C_Truck_02_covered_F"];
 	if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
@@ -535,7 +886,6 @@ a3e_arr_Escape_EnemyCivilianCarTypes = [
 	if(Param_UseDLCLaws==1) then {
 	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_medevac_F";
 	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_vehicle_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_service_F";
 	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_transport_F";
 	};
 
@@ -548,38 +898,17 @@ a3e_arr_Escape_AmmoDepot_StaticWeaponClasses = [
 	,"B_HMG_01_high_F"
 	,"B_static_AT_F"
 	,"B_static_AA_F"];
+	
+	
 // An ammo depot have one parked and empty vehicle of the following possible types.
-a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
-	"I_G_Offroad_01_repair_F"
-	,"B_MRAP_01_F"
-	,"B_MRAP_01_gmg_F"
-	,"B_MRAP_01_hmg_F"
-	,"B_MRAP_01_F"
-	,"I_G_Offroad_01_armed_F"
-	,"I_G_Offroad_01_AT_F"
-	,"I_MRAP_03_hmg_F"
-	,"I_MRAP_03_gmg_F"
-	,"I_G_Offroad_01_F"
-	,"B_Truck_01_transport_F"
-	,"B_Truck_01_covered_F"
-	,"B_Truck_01_ammo_F"
-	,"B_Truck_01_fuel_F"
-	,"B_Truck_01_medical_F"
-	,"B_Truck_01_Repair_F"
-	,"B_Truck_01_box_F"
-	,"B_Truck_01_mover_F"];
-	if(Param_UseDLCApex==1) then {
-		a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses pushback "B_LSV_01_unarmed_F";
-		a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses pushback "B_LSV_01_armed_F";
-		a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses pushback "B_LSV_01_AT_F";
-	};
+a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
+
+
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
 	"B_Heli_Attack_01_dynamicLoadout_F"];
 a3e_arr_O_transport_heli = [
-	"B_Heli_Transport_01_F"
-	,"B_Heli_Transport_01_F"
-	,"B_Heli_Light_01_F"];
+	"B_Heli_Transport_01_F"];
 	if(Param_UseDLCHelis==1) then {
 	a3e_arr_O_transport_heli pushback "B_Heli_Transport_03_F";
 	a3e_arr_O_transport_heli pushback "B_Heli_Transport_03_unarmed_F";
@@ -588,9 +917,7 @@ a3e_arr_O_pilots = [
 	"B_Helipilot_F"
 	,"B_helicrew_F"];
 a3e_arr_I_transport_heli = [
-	"I_Heli_Transport_02_F"
-	,"I_Heli_light_03_F"
-	,"I_Heli_light_03_unarmed_F"];
+	"I_Heli_Transport_02_F"];
 a3e_arr_I_pilots = [
 	"I_helipilot_F"
 	,"I_helicrew_F"];
@@ -608,40 +935,46 @@ a3e_arr_I_pilots = [
 a3e_arr_AmmoDepotBasicWeapons = [];
 // CSAT weapons
 a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_P07_F", 50, 4, 8, ["16Rnd_9x21_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["SMG_01_F", 50, 4, 8, ["30Rnd_45ACP_Mag_SMG_01"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MX_F", 100, 2, 4, ["30Rnd_65x39_caseless_mag"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["SMG_01_F", 10, 4, 8, ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MX_F", 100, 2, 4, ["30Rnd_65x39_caseless_mag","30Rnd_65x39_caseless_mag_Tracer"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MX_Black_F", 100, 2, 4, ["30Rnd_65x39_caseless_black_mag","30Rnd_65x39_caseless_black_mag_Tracer"], 6];
 a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MXC_F", 50, 2, 4, ["30Rnd_65x39_caseless_mag","30Rnd_65x39_caseless_mag_Tracer"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MX_GL_F", 75, 2, 4, ["30Rnd_65x39_caseless_mag", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_F", 50, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_GL_F", 50, 2, 4, ["30Rnd_556x45_Stanag", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20C_F", 50, 2, 4, ["30Rnd_556x45_Stanag"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MXC_Black_F", 50, 2, 4, ["30Rnd_65x39_caseless_black_mag","30Rnd_65x39_caseless_black_mag_Tracer"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MX_GL_F", 75, 2, 4, ["30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag_Tracer", "1Rnd_HE_Grenade_shell"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_MX_GL_Black_F", 75, 2, 4, ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer", "1Rnd_HE_Grenade_shell"], 4];
 // non-CSAT weapons
-a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_P07_F", 10, 4, 8, ["16Rnd_9x21_Mag", "30Rnd_9x21_Mag"], 6];
 a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_PDW2000_F", 20, 4, 8, ["16Rnd_9x21_Mag", "30Rnd_9x21_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_Pistol_heavy_02_F", 10, 4, 8, ["6Rnd_45ACP_Cylinder"], 6];
 a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_ACPC2_F", 20, 4, 8, ["9Rnd_45ACP_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["SMG_02_F", 10, 4, 8, ["30Rnd_9x21_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_SDAR_F", 10, 2, 4, ["20Rnd_556x45_UW_mag", "30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG20_F", 10, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_F", 10, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_GL_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_F", 50, 2, 4, ["30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow", "30Rnd_556x45_Stanag"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_GL_F", 50, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20C_F", 50, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG20_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_GL_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 6];
 
 // Weapons and ammo in the special weapons box
 a3e_arr_AmmoDepotSpecialWeapons = [];
 // CSAT weapons
-a3e_arr_AmmoDepotSpecialWeapons pushback ["arifle_MXM_F", 50, 2, 4, ["30Rnd_65x39_caseless_mag"], 8];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["arifle_MXM_DMS_F", 50, 2, 4, ["30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag_Tracer"], 8];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["arifle_MXM_Black_MOS_Pointer_Bipod_F", 50, 2, 4, ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], 8];
 a3e_arr_AmmoDepotSpecialWeapons pushback ["arifle_MX_SW_F", 50, 2, 4, ["100Rnd_65x39_caseless_mag","100Rnd_65x39_caseless_mag_Tracer"], 4];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_EBR_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_GM6_F", 10, 2, 4, ["5Rnd_127x108_Mag"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["arifle_MX_SW_Black_F", 50, 2, 4, ["100Rnd_65x39_caseless_mag","100Rnd_65x39_caseless_mag_Tracer"], 4];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_LRR_camo_LRPS_F", 10, 1, 1, ["7Rnd_408_Mag"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_LRR_LRPS_F", 10, 1, 1, ["7Rnd_408_Mag"], 9];
 if(Param_UseDLCMarksmen==1) then {
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["MMG_02_sand_F", 30, 2, 4, ["130Rnd_338_Mag"], 6];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_06_olive_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 10];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_03_tan_F", 30, 2, 4, ["20Rnd_762x51_Mag"], 10];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_02_sniper_F", 10, 2, 4, ["10Rnd_338_Mag"], 12];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["MMG_02_sand_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["MMG_02_camo_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["MMG_02_black_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_02_camo_AMS_LP_F", 30, 2, 4, ["10Rnd_338_Mag"], 10];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_02_sniper_AMS_LP_S_F", 10, 2, 4, ["10Rnd_338_Mag"], 10];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_03_AMS_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 12];
 };
 // non-CAST weapons
-//a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_LRR_F", 100, 2, 4, ["7Rnd_408_Mag"], 9];
 a3e_arr_AmmoDepotSpecialWeapons pushback ["LMG_Mk200_F", 20, 2, 4, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], 6];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_EBR_MRCO_LP_BI_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 9];
+if(Param_UseDLCMarksmen==1) then {
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_06_camo_khs_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 10];
+};
 
 
 // Weapons and ammo in the launchers box
@@ -665,7 +998,7 @@ a3e_arr_AmmoDepotOrdnance = [];
 // General weapons
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["DemoCharge_Remote_Mag", "SatchelCharge_Remote_Mag"], 5];
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["APERSMine_Range_Mag", "APERSBoundingMine_Range_Mag", "APERSTripMine_Wire_Mag"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "SLAMDirectionalMine_Wire_Mag"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "SLAMDirectionalMine_Wire_Mag", "ATMine_Range_Mag"], 5];
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["Laserbatteries"], 5];
 
 // Weapons and ammo in the vehicle box (the big one)
@@ -674,17 +1007,17 @@ a3e_arr_AmmoDepotVehicle = [];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["HandGrenade", "MiniGrenade"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["SmokeShell", "SmokeShellYellow", "SmokeShellRed", "SmokeShellGreen", "SmokeShellPurple", "SmokeShellBlue", "SmokeShellOrange"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow"], 50];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_Smoke_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeOrange_Grenade_shell", "1Rnd_SmokePurple_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeYellow_Grenade_shell"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["3Rnd_Smoke_Grenade_shell", "3Rnd_SmokeBlue_Grenade_shell", "3Rnd_SmokeGreen_Grenade_shell", "3Rnd_SmokeOrange_Grenade_shell", "3Rnd_SmokePurple_Grenade_shell", "3Rnd_SmokeRed_Grenade_shell", "3Rnd_SmokeYellow_Grenade_shell"], 5];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_Smoke_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeOrange_Grenade_shell", "1Rnd_SmokePurple_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeYellow_Grenade_shell"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["3Rnd_Smoke_Grenade_shell", "3Rnd_SmokeBlue_Grenade_shell", "3Rnd_SmokeGreen_Grenade_shell", "3Rnd_SmokeOrange_Grenade_shell", "3Rnd_SmokePurple_Grenade_shell", "3Rnd_SmokeRed_Grenade_shell", "3Rnd_SmokeYellow_Grenade_shell"], 25];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["FlareWhite_F", "FlareGreen_F", "FlareRed_F", "FlareYellow_F"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["UGL_FlareWhite_F", "UGL_FlareGreen_F", "UGL_FlareRed_F", "UGL_FlareYellow_F", "UGL_FlareCIR_F"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["3Rnd_UGL_FlareWhite_F", "3Rnd_UGL_FlareGreen_F", "3Rnd_UGL_FlareRed_F", "3Rnd_UGL_FlareYellow_F", "3Rnd_UGL_FlareCIR_F"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_HE_Grenade_shell", "3Rnd_HE_Grenade_shell"], 5];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["UGL_FlareWhite_F", "UGL_FlareGreen_F", "UGL_FlareRed_F", "UGL_FlareYellow_F", "UGL_FlareCIR_F"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["3Rnd_UGL_FlareWhite_F", "3Rnd_UGL_FlareGreen_F", "3Rnd_UGL_FlareRed_F", "3Rnd_UGL_FlareYellow_F", "3Rnd_UGL_FlareCIR_F"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_HE_Grenade_shell", "3Rnd_HE_Grenade_shell"], 25];
 a3e_arr_AmmoDepotVehicleItems = [];
 a3e_arr_AmmoDepotVehicleItems pushback ["ToolKit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["Medikit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["FirstAidKit", 100, 10, 50, [], 0];
-a3e_arr_AmmoDepotVehicleBackpacks = ["O_UAV_01_backpack_F"];
+a3e_arr_AmmoDepotVehicleBackpacks = ["B_TacticalPack_mcamo"];
 // Items
 
 // Index 0: Item classname.
@@ -755,14 +1088,13 @@ a3e_arr_CivilianCarWeapons pushback ["hgun_ACPC2_F", "9Rnd_45ACP_Mag", 12];
 a3e_arr_CivilianCarWeapons pushback ["arifle_MXM_Hamr_pointer_F", "30Rnd_65x39_caseless_mag_Tracer", 8];
 a3e_arr_CivilianCarWeapons pushback ["arifle_MX_Hamr_pointer_F", "30Rnd_65x39_caseless_mag_Tracer", 6];
 a3e_arr_CivilianCarWeapons pushback ["arifle_MXM_SOS_pointer_F", "30Rnd_65x39_caseless_mag_Tracer", 7];
-a3e_arr_CivilianCarWeapons pushback ["arifle_Katiba_C_F", "30Rnd_65x39_caseless_green", 5];
+a3e_arr_CivilianCarWeapons pushback ["arifle_TRG21_F", "30Rnd_556x45_Stanag", 6];
 a3e_arr_CivilianCarWeapons pushback ["arifle_Mk20_GL_ACO_F", "UGL_FlareWhite_F", 8];
 a3e_arr_CivilianCarWeapons pushback ["SMG_01_Holo_F", "30Rnd_45ACP_Mag_SMG_01_Tracer_Green", 5];
-a3e_arr_CivilianCarWeapons pushback ["SMG_02_ACO_F", "30Rnd_9x21_Mag", 12];
 if(Param_UseDLCMarksmen==1) then {
 	a3e_arr_CivilianCarWeapons pushback ["srifle_DMR_06_camo_khs_F", "20Rnd_762x51_Mag", 8];
 };
-a3e_arr_CivilianCarWeapons pushback ["launch_RPG32_F", "RPG32_F", 2];
+a3e_arr_CivilianCarWeapons pushback ["launch_MRAWS_sand_F", "MRAWS_HEAT_F", 2];
 a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Medikit", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Toolkit", objNull, 0];
@@ -952,23 +1284,19 @@ a3e_arr_CrashSiteCrewCar = [
 	"O_crew_F"];
 // Weapons and ammo in crash site box
 a3e_arr_CrashSiteWeapons = [];
-a3e_arr_CrashSiteWeapons pushback ["launch_RPG32_F", 10, 1, 2, ["RPG32_F","RPG32_HE_F"], 3];
-a3e_arr_CrashSiteWeapons pushback ["launch_O_Vorona_brown_F", 10, 1, 2, ["Vorona_HEAT","Vorona_HE"], 2];
-a3e_arr_CrashSiteWeapons pushback ["arifle_Katiba_C_ACO_F", 75, 2, 4, ["30Rnd_65x39_caseless_green"], 6];
+a3e_arr_CrashSiteWeapons pushback ["SMG_02_ACO_F", 50, 1, 2, ["30Rnd_9x21_Mag_SMG_02"], 8];
+a3e_arr_CrashSiteWeapons pushback ["launch_RPG32_F", 25, 1, 2, ["RPG32_F","RPG32_HE_F"], 3];
+a3e_arr_CrashSiteWeapons pushback ["launch_O_Vorona_brown_F", 10, 1, 1, ["Vorona_HEAT","Vorona_HE"], 2];
+a3e_arr_CrashSiteWeapons pushback ["arifle_Katiba_C_F", 75, 2, 4, ["30Rnd_65x39_caseless_green"], 6];
 a3e_arr_CrashSiteWeapons pushback ["arifle_Katiba_F", 75, 2, 4, ["30Rnd_65x39_caseless_green"], 6];
+a3e_arr_CrashSiteWeapons pushback ["arifle_Katiba_GL_F", 75, 2, 4, ["30Rnd_65x39_caseless_green", "1Rnd_HE_Grenade_shell"], 4];
 a3e_arr_CrashSiteWeapons pushback ["LMG_Zafir_F", 60, 1, 3, ["150Rnd_762x54_Box_Tracer"], 4];
 a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_01_DMS_F", 40, 1, 2, ["10Rnd_762x54_Mag"], 8];
-if(Param_UseDLCApex==1) then {
-	a3e_arr_CrashSiteWeapons pushback ["arifle_ARX_hex_DMS_Pointer_Snds_Bipod_F", 10, 1, 2, ["30Rnd_65x39_caseless_green","10Rnd_50BW_Mag_F"], 8];
-	a3e_arr_CrashSiteWeapons pushback ["arifle_CTAR_blk_F", 75, 2, 4, ["30Rnd_580x42_Mag_F"], 6];
-	a3e_arr_CrashSiteWeapons pushback ["arifle_CTAR_GL_blk_F", 50, 2, 4, ["30Rnd_65x39_caseless_green", "1Rnd_HE_Grenade_shell", "UGL_FlareGreen_F"], 6];
-	a3e_arr_CrashSiteWeapons pushback ["arifle_CTARS_blk_F", 20, 1, 2, ["100Rnd_580x42_Mag_Tracer_F"], 6];
-};
 if(Param_UseDLCMarksmen==1) then {
-	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_07_blk_DMS_F", 10, 1, 2, ["20Rnd_650x39_Cased_Mag_F"], 8];
-	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_04_MRCO_F", 10, 1, 2, ["10Rnd_127x54_Mag"], 8];
+	a3e_arr_CrashSiteWeapons pushback ["MMG_01_hex_F", 30, 2, 4, ["150Rnd_93x64_Mag"], 6];
+	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_04_DMS_F", 10, 2, 4, ["10Rnd_127x54_Mag"], 12];
+	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_05_KHS_LP_F", 10, 2, 4, ["10Rnd_93x64_DMR_05_Mag"], 12];
 };
-a3e_arr_CrashSiteWeapons pushback ["SMG_02_ACO_F", 10, 1, 2, ["30Rnd_9x21_Mag_SMG_02_Tracer_Green"], 8];
 // Attachments and other items in crash site box
 a3e_arr_CrashSiteItems = [];
 a3e_arr_CrashSiteItems pushback ["optic_Hamr", 10, 1, 3];
@@ -977,3 +1305,4 @@ a3e_arr_CrashSiteItems pushback ["optic_Aco_smg", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["optic_Holosight", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["optic_SOS", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["muzzle_snds_H", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["O_UavTerminal", 50, 1, 1];

--- a/Mods/Vanilla/UnitClasses.sqf
+++ b/Mods/Vanilla/UnitClasses.sqf
@@ -29,34 +29,58 @@ a3e_arr_Escape_StartPositionGuardTypes = [
 
 // Prison backpack secondary weapon (and corresponding magazine type).
 a3e_arr_PrisonBackpackWeapons = [];
+//Pistols
 a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_F","9Rnd_45ACP_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_ACPC2_snds_F","9Rnd_45ACP_Mag"];
 a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_F","16Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_PDW2000_F","30Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_F","16Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_snds_F","16Rnd_9x21_Mag"];
 a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_02_F","6Rnd_45ACP_Cylinder"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_P07_snds_F","30Rnd_9x21_Mag"];
-a3e_arr_PrisonBackpackWeapons pushback ["hgun_Rook40_snds_F","30Rnd_9x21_Mag"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_02_F","6Rnd_45ACP_Cylinder"];
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_Pistol_heavy_02_Yorris_F","6Rnd_45ACP_Cylinder"];
+//SMGs
+a3e_arr_PrisonBackpackWeapons pushback ["hgun_PDW2000_F","30Rnd_9x21_Mag"];
 
 // Random array. Civilian vehicle classes for ambient traffic.
 a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 	"C_Hatchback_01_F"
-	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
-	,"C_SUV_01_F"
+	,"C_Hatchback_01_F"
+	,"C_Hatchback_01_F"
+	,"C_Hatchback_01_F"
 	,"C_Hatchback_01_F"
 	,"C_Hatchback_01_sport_F"
+	,"C_Hatchback_01_sport_F"
+	,"C_Offroad_01_F"
+	,"C_Offroad_01_F"
+	,"C_Offroad_01_F"
+	,"C_Offroad_01_F"
 	,"C_Offroad_01_F"
 	,"C_Quadbike_01_F"
+	,"C_Quadbike_01_F"
+	,"C_Quadbike_01_F"
 	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
+	,"C_SUV_01_F"
 	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
+	,"C_Van_01_transport_F"
 	,"C_Truck_02_covered_F"
+	,"C_Truck_02_covered_F"
+	,"C_Truck_02_transport_F"
+	,"C_Truck_02_transport_F"
+	//Supply Trucks
+	,"C_Van_01_fuel_F"
+	,"C_Van_01_box_F"
 	,"C_Offroad_01_repair_F"
 	,"C_Truck_02_fuel_F"
-	,"C_Truck_02_box_F"
-	,"C_Truck_02_transport_F"];
+	,"C_Truck_02_box_F"];
 	if(Param_UseDLCApex==1) then {
 	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Offroad_02_unarmed_F";
 	};
@@ -72,103 +96,249 @@ a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
 switch (_enemyFrequency) do {
     case 1: {//Few (1-3)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"O_MRAP_02_F"
+		//Unarmed Cars/UAVs 2 sets
+		"O_MRAP_02_F"  //1
 		,"O_MRAP_02_F"
 		,"O_MRAP_02_F"
 		,"O_MRAP_02_F"
-		,"O_MRAP_02_hmg_F"
-		,"O_MRAP_02_hmg_F"
 		,"O_Quadbike_01_F"
 		,"O_Quadbike_01_F"
 		,"O_Quadbike_01_F"
-		,"O_UGV_01_rcws_F"
-		,"O_Truck_02_covered_F"
-		,"O_Truck_02_transport_F"
-		,"O_Truck_02_ammo_F"
-		,"O_Truck_02_box_F"
-		,"O_Truck_02_fuel_F"
+		,"O_Truck_03_device_F"
+		,"O_Truck_03_medical_F"
+		,"O_Truck_03_transport_F"
+		,"O_Truck_03_covered_F"
 		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		,"O_UGV_01_F"
+		,"O_MRAP_02_F"  //2
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Truck_03_device_F"
+		,"O_Truck_03_medical_F"
+		,"O_Truck_03_transport_F"
+		,"O_Truck_03_covered_F"
+		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		,"O_UGV_01_F"
+		//Supply Trucks  1 set
+	    ,"O_Truck_03_ammo_F"
+		,"O_Truck_03_fuel_F"
+		,"O_Truck_03_repair_F"
+		,"O_Truck_02_ammo_F"
+		,"O_Truck_02_fuel_F"
+		,"O_Truck_02_box_F"
+		//Armed UAVs  1 set
+		,"O_UGV_01_rcws_F"
+		,"O_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		//Heavily Armed APCs or AA  1 set
 		,"O_APC_Wheeled_02_rcws_F"
 		,"O_APC_Tracked_02_AA_F"
 		,"O_APC_Tracked_02_cannon_F"
+		//Artillery  1 set
 		,"O_MBT_02_arty_F"
-		,"O_MBT_02_cannon_F"
-		,"O_Truck_03_device_F"
-		,"O_Truck_03_transport_F"
-		,"O_Truck_03_covered_F"
-		,"O_Truck_03_ammo_F"
-		,"O_Truck_03_fuel_F"
-		,"O_Truck_03_medical_F"
-		,"O_Truck_03_repair_F"];
+		//Tanks  1 set
+		,"O_MBT_02_cannon_F"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
 		};
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_MBT_04_cannon_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_MBT_04_command_F";
 		};
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"I_G_Offroad_01_repair_F"
+		//Unarmed Cars/UAVs  3 sets
+		"I_Quadbike_01_F"  //1
 		,"I_MRAP_03_F"
-		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_AT_F"
-		,"I_G_Offroad_01_AT_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
 		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //2
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //3
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		//Supply Trucks  1 set
+		,"I_Truck_02_ammo_F"
+		,"I_Truck_02_fuel_F"
+		,"I_Truck_02_box_F"
+		,"I_G_Van_01_fuel_F"
+		,"I_G_Offroad_01_repair_F"
+		//Armed Cars  1 set
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		//Armed UAVs  1 set
 		,"I_UGV_01_rcws_F"
-		,"I_Truck_02_MRL_F"
-		,"I_MBT_03_cannon_F"
+		,"I_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		//Heavily Armed APCs or AA  1 set
+		,"I_APC_Wheeled_03_cannon_F"
 		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"];
+		//Artillery  1 set
+		,"I_Truck_02_MRL_F"
+		//Tanks  1 set
+		,"I_MBT_03_cannon_F"];
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
 		};
+		if(Param_UseDLCLaws==1) then {
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+	    };
     };
     case 2: {//Some (4-6)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"O_MRAP_02_F"
+		//Unarmed Cars/UAVs 2 sets
+		"O_MRAP_02_F"  //1
 		,"O_MRAP_02_F"
 		,"O_MRAP_02_F"
-		,"O_MRAP_02_hmg_F"
-		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_F"
 		,"O_Quadbike_01_F"
 		,"O_Quadbike_01_F"
-		,"O_UGV_01_rcws_F"
-		,"O_Truck_02_covered_F"
-		,"O_Truck_02_transport_F"
-		,"O_Truck_02_ammo_F"
-		,"O_Truck_02_box_F"
-		,"O_Truck_02_fuel_F"
-		,"O_Truck_02_medical_F"
-		,"O_APC_Wheeled_02_rcws_F"
-		,"O_APC_Tracked_02_AA_F"
-		,"O_APC_Tracked_02_cannon_F"
-		,"O_APC_Wheeled_02_rcws_F"
-		,"O_APC_Tracked_02_AA_F"
-		,"O_APC_Tracked_02_cannon_F"
-		,"O_MBT_02_arty_F"
-		,"O_MBT_02_arty_F"
-		,"O_MBT_02_cannon_F"
-		,"O_MBT_02_cannon_F"
+		,"O_Quadbike_01_F"
 		,"O_Truck_03_device_F"
+		,"O_Truck_03_medical_F"
 		,"O_Truck_03_transport_F"
 		,"O_Truck_03_covered_F"
-		,"O_Truck_03_ammo_F"
-		,"O_Truck_03_fuel_F"
+		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		,"O_UGV_01_F"
+		,"O_MRAP_02_F"  //2
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Truck_03_device_F"
 		,"O_Truck_03_medical_F"
-		,"O_Truck_03_repair_F"];
+		,"O_Truck_03_transport_F"
+		,"O_Truck_03_covered_F"
+		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		,"O_UGV_01_F"
+		//Supply Trucks  1 set
+	    ,"O_Truck_03_ammo_F"
+		,"O_Truck_03_fuel_F"
+		,"O_Truck_03_repair_F"
+		,"O_Truck_02_ammo_F"
+		,"O_Truck_02_fuel_F"
+		,"O_Truck_02_box_F"
+		//Armed UAVs  2 sets
+		,"O_UGV_01_rcws_F"  //1
+		,"O_UGV_01_rcws_F"
+		,"O_UGV_01_rcws_F"  //2
+		,"O_UGV_01_rcws_F"
+		//MRAPS  2 sets
+		,"O_MRAP_02_gmg_F"  //1
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_gmg_F"  //2
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		//Heavily Armed APCs or AA  1 set
+		,"O_APC_Wheeled_02_rcws_F"
+		,"O_APC_Tracked_02_AA_F"
+		,"O_APC_Tracked_02_cannon_F"
+		//Artillery  1 set
+		,"O_MBT_02_arty_F"
+		//Tanks  1 set
+		,"O_MBT_02_cannon_F"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
 		};
 		if(Param_UseDLCTanks==1) then {
@@ -176,69 +346,184 @@ switch (_enemyFrequency) do {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_MBT_04_command_F";
 		};
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"I_G_Offroad_01_repair_F",
-		"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
+		//Unarmed Cars/UAVs  3 sets
+		"I_Quadbike_01_F"  //1
 		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_AT_F"
-		,"I_G_Offroad_01_AT_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
 		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //2
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //3
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		//Supply Trucks  1 set
+		,"I_Truck_02_ammo_F"
+		,"I_Truck_02_fuel_F"
+		,"I_Truck_02_box_F"
+		,"I_G_Van_01_fuel_F"
+		,"I_G_Offroad_01_repair_F"
+		//Armed Cars  2 sets
+		,"I_G_Offroad_01_AT_F"  //1
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_AT_F"  //2
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		//Armed UAVs  2 sets
+		,"I_UGV_01_rcws_F"  //1
 		,"I_UGV_01_rcws_F"
+		,"I_UGV_01_rcws_F"  //2
+		,"I_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		//Heavily Armed APCs or AA  1 set
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		//Artillery  1 set
 		,"I_Truck_02_MRL_F"
-		,"I_MBT_03_cannon_F"
-		,"I_MBT_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"];
+		//Tanks  1 set
+		,"I_MBT_03_cannon_F"];
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
 		};
+		if(Param_UseDLCLaws==1) then {
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+	    };
     };
     default {//A lot (7-8)
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses = [
-		"O_MRAP_02_F"
+		//Unarmed Cars/UAVs 2 sets
+		"O_MRAP_02_F"  //1
 		,"O_MRAP_02_F"
 		,"O_MRAP_02_F"
-		,"O_MRAP_02_hmg_F"
-		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_F"
 		,"O_Quadbike_01_F"
 		,"O_Quadbike_01_F"
-		,"O_UGV_01_rcws_F"
-		,"O_Truck_02_covered_F"
-		,"O_Truck_02_transport_F"
-		,"O_Truck_02_ammo_F"
-		,"O_Truck_02_box_F"
-		,"O_Truck_02_fuel_F"
-		,"O_Truck_02_medical_F"
-		,"O_APC_Wheeled_02_rcws_F"
-		,"O_APC_Tracked_02_AA_F"
-		,"O_APC_Tracked_02_cannon_F"
-		,"O_APC_Wheeled_02_rcws_F"
-		,"O_APC_Tracked_02_AA_F"
-		,"O_APC_Tracked_02_cannon_F"
-		,"O_MBT_02_arty_F"
-		,"O_MBT_02_arty_F"
-		,"O_MBT_02_cannon_F"
-		,"O_MBT_02_cannon_F"
+		,"O_Quadbike_01_F"
 		,"O_Truck_03_device_F"
+		,"O_Truck_03_medical_F"
 		,"O_Truck_03_transport_F"
 		,"O_Truck_03_covered_F"
-		,"O_Truck_03_ammo_F"
-		,"O_Truck_03_fuel_F"
+		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		,"O_UGV_01_F"
+		,"O_MRAP_02_F"  //2
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Truck_03_device_F"
 		,"O_Truck_03_medical_F"
-		,"O_Truck_03_repair_F"];
+		,"O_Truck_03_transport_F"
+		,"O_Truck_03_covered_F"
+		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		,"O_UGV_01_F"
+		//Supply Trucks  1 set
+	    ,"O_Truck_03_ammo_F"
+		,"O_Truck_03_fuel_F"
+		,"O_Truck_03_repair_F"
+		,"O_Truck_02_ammo_F"
+		,"O_Truck_02_fuel_F"
+		,"O_Truck_02_box_F"
+		//Armed UAVs  2 sets
+		,"O_UGV_01_rcws_F"  //1
+		,"O_UGV_01_rcws_F"
+		,"O_UGV_01_rcws_F"  //2
+		,"O_UGV_01_rcws_F"
+		//MRAPS  2 sets
+		,"O_MRAP_02_gmg_F"  //1
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_gmg_F"  //2
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		,"O_MRAP_02_hmg_F"
+		//Heavily Armed APCs or AA  2 sets
+		,"O_APC_Wheeled_02_rcws_F"
+		,"O_APC_Tracked_02_AA_F"
+		,"O_APC_Tracked_02_cannon_F"
+		,"O_APC_Wheeled_02_rcws_F"
+		,"O_APC_Tracked_02_AA_F"
+		,"O_APC_Tracked_02_cannon_F"
+		//Artillery  1 set
+		,"O_MBT_02_arty_F"
+		//Tanks  2 sets
+		,"O_MBT_02_cannon_F"
+		,"O_MBT_02_cannon_F"];
 		if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_unarmed_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_armed_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_LSV_02_AT_F";
 		};
 		if(Param_UseDLCTanks==1) then {
@@ -246,40 +531,104 @@ switch (_enemyFrequency) do {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses pushback "O_MBT_04_command_F";
 		};
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		"I_G_Offroad_01_repair_F"
+		//Unarmed Cars/UAVs  3 sets
+		"I_Quadbike_01_F"  //1
 		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_MRAP_03_F"
-		,"I_MRAP_03_hmg_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_armed_F"
-		,"I_G_Offroad_01_AT_F"
-		,"I_G_Offroad_01_AT_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
 		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //2
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		,"I_Quadbike_01_F"  //3
+		,"I_MRAP_03_F"
+		,"I_Truck_02_medical_F"
+		,"I_Truck_02_transport_F"
+		,"I_Truck_02_covered_F"
+		,"I_G_Offroad_01_F"
+		,"I_G_Quadbike_01_F"
+		,"I_G_Van_01_transport_F"
+		,"I_UGV_01_F"
+		//Supply Trucks  1 set
+		,"I_Truck_02_ammo_F"
+		,"I_Truck_02_fuel_F"
+		,"I_Truck_02_box_F"
+		,"I_G_Van_01_fuel_F"
+		,"I_G_Offroad_01_repair_F"
+		//Armed Cars  2 sets
+		,"I_G_Offroad_01_AT_F"  //1
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_AT_F"  //2
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_AT_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		,"I_G_Offroad_01_armed_F"
+		//Armed UAVs  2 sets
+		,"I_UGV_01_rcws_F"  //1
 		,"I_UGV_01_rcws_F"
+		,"I_UGV_01_rcws_F"  //2
+		,"I_UGV_01_rcws_F"
+		//MRAPS  1 set
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_gmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		,"I_MRAP_03_hmg_F"
+		//Heavily Armed APCs or AA  2 sets
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		,"I_APC_Wheeled_03_cannon_F"
+		,"I_APC_tracked_03_cannon_F"
+		//Artillery  1 set
 		,"I_Truck_02_MRL_F"
+		//Tanks  2 sets
 		,"I_MBT_03_cannon_F"
-		,"I_MBT_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"
-		,"I_APC_tracked_03_cannon_F"];
+		,"I_MBT_03_cannon_F"];
 		if(Param_UseDLCTanks==1) then {
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
 		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AA_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_AT_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_scout_F";
+		a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND pushback "I_LT_01_cannon_F";
 		};
+		if(Param_UseDLCLaws==1) then {
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_transport_F";
+	    a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+		a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "I_G_Van_02_vehicle_F";
+	    };
     };
 };
+
 
 // Random array. General infantry types. E.g. village patrols, ambient infantry, etc. (for ammo depot guards and communication center guards see further down in this file at fn_InitGuardedLocations)
 a3e_arr_Escape_InfantryTypes = [
 	"O_engineer_F"
-	,"O_engineer_F"
-	,"O_engineer_F"
 	,"O_medic_F"
 	,"O_medic_F"
 	,"O_medic_F"
@@ -294,7 +643,8 @@ a3e_arr_Escape_InfantryTypes = [
 	,"O_Soldier_AT_F"
 	,"O_Soldier_AT_F"
 	,"O_Soldier_exp_F"
-	,"O_Soldier_exp_F"
+	,"O_soldier_F"
+	,"O_soldier_F"
 	,"O_soldier_F"
 	,"O_soldier_F"
 	,"O_soldier_F"
@@ -308,10 +658,7 @@ a3e_arr_Escape_InfantryTypes = [
 	,"O_Soldier_lite_F"
 	,"O_Soldier_M_F"
 	,"O_Soldier_M_F"
-	,"O_Soldier_M_F"
 	,"O_Soldier_repair_F"
-	,"O_Soldier_repair_F"
-	,"O_officer_F"
 	,"O_officer_F"
 	,"O_soldier_UAV_F"
 	,"O_soldier_UAV_F"
@@ -324,7 +671,9 @@ a3e_arr_Escape_InfantryTypes = [
 	,"O_support_MG_F"
 	,"O_support_Mort_F"
 	,"O_Soldier_AHAT_F"
-	,"O_Soldier_HAT_F"];
+	,"O_Soldier_HAT_F"
+	,"O_Soldier_SL_F"
+	,"O_Soldier_TL_F"];
 	if(Param_UseDLCMarksmen==1) then {
 		a3e_arr_Escape_InfantryTypes pushback "O_HeavyGunner_F";
 		a3e_arr_Escape_InfantryTypes pushback "O_Pathfinder_F";
@@ -337,8 +686,6 @@ a3e_arr_Escape_InfantryTypes = [
 	};
 a3e_arr_Escape_InfantryTypes_Ind = [
 	"I_engineer_F"
-	,"I_engineer_F"
-	,"I_engineer_F"
 	,"I_medic_F"
 	,"I_medic_F"
 	,"I_medic_F"
@@ -352,8 +699,8 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	,"I_Soldier_AR_F"
 	,"I_Soldier_AT_F"
 	,"I_Soldier_exp_F"
-	,"I_Soldier_exp_F"
-	,"I_Soldier_exp_F"
+	,"I_soldier_F"
+	,"I_soldier_F"
 	,"I_soldier_F"
 	,"I_soldier_F"
 	,"I_soldier_F"
@@ -369,8 +716,6 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	,"I_Soldier_M_F"
 	,"I_Soldier_M_F"
 	,"I_Soldier_repair_F"
-	,"I_Soldier_repair_F"
-	,"I_officer_F"
 	,"I_officer_F"
 	,"I_soldier_UAV_F"
 	,"I_soldier_UAV_F"
@@ -385,10 +730,9 @@ a3e_arr_Escape_InfantryTypes_Ind = [
 	,"I_Soldier_LAT2_F"
 	,"I_Soldier_LAT2_F"
 	,"I_Spotter_F"
-	,"I_Sniper_F"];
-	if(Param_UseDLCMarksmen==1) then {
-		a3e_arr_Escape_InfantryTypes_Ind pushback "I_ghillie_ard_F";
-	};
+	,"I_Sniper_F"
+	,"I_Soldier_SL_F"
+	,"I_Soldier_TL_F"];
 	if(Param_UseDLCLaws==1) then {
 		a3e_arr_Escape_InfantryTypes_Ind pushback "I_soldier_mine_F";
 		a3e_arr_Escape_InfantryTypes_Ind pushback "I_soldier_UAV_06_F";
@@ -403,8 +747,7 @@ a3e_arr_recon_InfantryTypes = [
 	,"O_recon_LAT_F"
 	,"O_recon_TL_F"];
 a3e_arr_recon_I_InfantryTypes = [
-	"I_G_officer_F"
-	,"I_G_Soldier_A_F"
+	"I_G_Soldier_A_F"
 	,"I_G_Soldier_LAT_F"
 	,"I_G_Soldier_M_F"
 	,"I_G_Soldier_GL_F"
@@ -417,30 +760,25 @@ a3e_arr_recon_I_InfantryTypes = [
 	,"I_G_Soldier_lite_F"
 	,"I_G_Soldier_F"
 	,"I_G_Soldier_LAT2_F"];
-	if(Param_UseDLCMarksmen==1) then {
-		a3e_arr_recon_I_InfantryTypes pushback "I_G_Sharpshooter_F";
-	};
+
 
 // Random array. A roadblock has a manned vehicle. This array contains possible manned vehicles (can be of any kind, like cars, armored and statics).
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
 	"O_MRAP_02_hmg_F"
 	,"O_MRAP_02_hmg_F"
 	,"O_MRAP_02_gmg_F"
-	,"O_UGV_01_rcws_F"
-	,"O_HMG_01_high_F"
-	,"O_static_AT_F"];
-	if(Param_UseDLCApex==1) then {
-		a3e_arr_Escape_RoadBlock_MannedVehicleTypes pushback "O_LSV_02_armed_F";
-		a3e_arr_Escape_RoadBlock_MannedVehicleTypes pushback "O_LSV_02_AT_F";
-	};
+	,"O_UGV_01_rcws_F"];
+	
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind = [
-	"I_G_Offroad_01_armed_F"
-	,"I_G_Offroad_01_AT_F"
+	"I_MRAP_03_hmg_F"
 	,"I_MRAP_03_hmg_F"
-	,"I_LT_01_cannon_F"
-	,"I_HMG_01_high_f"
-	,"I_static_AT_F"
-	,"I_G_Offroad_01_F"];
+	,"I_MRAP_03_gmg_F"
+	,"I_UGV_01_rcws_F"];
+	if(Param_UseDLCTanks==1) then {
+		a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "I_LT_01_AT_F";
+		a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind pushback "I_LT_01_cannon_F";	
+	};
+
 
 // Random array. Vehicle classes (preferrably trucks) transporting enemy reinforcements.
 a3e_arr_Escape_ReinforcementTruck_vehicleClasses = [
@@ -453,17 +791,11 @@ a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind = [
 	,"I_Truck_02_covered"];
 
 
-
-
 // Random array. Motorized search groups are sometimes sent to look for you. This array contains possible class definitions for the vehicles.
 a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 	"O_APC_Wheeled_02_rcws_F"
-	,"O_APC_Tracked_02_cannon_F"
 	,"O_APC_Wheeled_02_rcws_F"
-	,"I_MRAP_03_hmg_F"];
-	if(Param_UseDLCTanks==1) then {
-		a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses pushback "I_LT_01_cannon_F";
-	};
+	,"O_APC_Tracked_02_cannon_F"];
 
 
 // A communication center is guarded by vehicles depending on variable _enemyFrequency. 1 = a random light armor. 2 = a random heavy armor. 3 = a random 
@@ -477,10 +809,8 @@ a3e_arr_ComCenDefence_lightArmorClasses = [
 // Random array. Heavy armored vehicles guarding the communication centers.
 a3e_arr_ComCenDefence_heavyArmorClasses = [
 	"O_MBT_02_cannon_F"
-	,"O_APC_Tracked_02_cannon_F"
 	,"O_APC_Tracked_02_AA_F"];
 	if(Param_UseDLCTanks==1) then {
-		a3e_arr_ComCenDefence_heavyArmorClasses pushback "O_MBT_04_cannon_F";
 		a3e_arr_ComCenDefence_heavyArmorClasses pushback "O_MBT_04_command_F";
 	};
 
@@ -492,29 +822,32 @@ a3e_arr_ComCenStaticWeapons = [
 	,"O_GMG_01_high_F"];
 // A communication center have two parked and empty vehicles of the following possible types.
 a3e_arr_ComCenParkedVehicles = [
-	"I_G_Offroad_01_repair_F"
-	,"O_Truck_02_fuel_F"
-	,"O_Truck_02_medical_F"
-	,"O_Truck_02_covered_F"
-	,"O_Truck_02_transport_F"
-	,"O_MRAP_02_F"
-	,"O_MRAP_02_gmg_F"
-	,"O_MRAP_02_hmg_F"
-	,"O_Truck_02_ammo_F"
-	,"O_Truck_02_box_F"
-	,"O_MRAP_02_F"
-	,"I_G_Offroad_01_armed_F"
-	,"I_G_Offroad_01_AT_F"
-	,"I_MRAP_03_hmg_F"
-	,"I_MRAP_03_gmg_F"
-	,"I_G_Offroad_01_F"
-	,"O_Truck_03_device_F"
-	,"O_Truck_03_transport_F"
-	,"O_Truck_03_covered_F"
-	,"O_Truck_03_ammo_F"
-	,"O_Truck_03_fuel_F"
-	,"O_Truck_03_medical_F"
-	,"O_Truck_03_repair_F"];
+		"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_MRAP_02_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Quadbike_01_F"
+		,"O_Truck_03_device_F"
+		,"O_Truck_03_medical_F"
+		,"O_Truck_03_transport_F"
+		,"O_Truck_03_covered_F"
+		,"O_Truck_02_medical_F"
+		,"O_Truck_02_transport_F"
+		,"O_Truck_02_covered_F"
+		//Supply Trucks
+	    ,"O_Truck_03_ammo_F"
+		,"O_Truck_03_fuel_F"
+		,"O_Truck_03_repair_F"
+		,"O_Truck_02_ammo_F"
+		,"O_Truck_02_fuel_F"
+		,"O_Truck_02_box_F"
+		//Armed Cars
+		,"O_UGV_01_rcws_F"
+		//MRAPS
+		,"O_MRAP_02_gmg_F"
+		,"O_MRAP_02_hmg_F"];
 	if(Param_UseDLCApex==1) then {
 		a3e_arr_ComCenParkedVehicles pushback "O_LSV_02_unarmed_F";
 		a3e_arr_ComCenParkedVehicles pushback "O_LSV_02_armed_F";
@@ -525,12 +858,7 @@ a3e_arr_ComCenParkedVehicles = [
 a3e_arr_Escape_EnemyCivilianCarTypes = [
 	"C_Hatchback_01_F"
 	,"C_Hatchback_01_sport_F"
-	,"C_Offroad_01_F"
-	,"C_Quadbike_01_F"
 	,"C_SUV_01_F"
-	,"C_Van_01_box_F"
-	,"C_Van_01_transport_F"
-	,"C_Van_01_fuel_F"
 	,"C_Truck_02_covered_F"];
 	if(Param_UseDLCApex==1) then {
 		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
@@ -538,45 +866,23 @@ a3e_arr_Escape_EnemyCivilianCarTypes = [
 	if(Param_UseDLCLaws==1) then {
 	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_medevac_F";
 	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_vehicle_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_service_F";
 	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_transport_F";
 	};
+
 
 // Vehicles, weapons and ammo at ammo depots
 
 // Random array. An ammo depot contains one static weapon of the following types:
 a3e_arr_Escape_AmmoDepot_StaticWeaponClasses = [
 	"O_HMG_01_high_F"
-	,"O_GMG_01_high_F"
 	,"O_HMG_01_high_F"
+	,"O_GMG_01_high_F"
 	,"O_static_AT_F"
 	,"O_static_AA_F"];
+
 // An ammo depot have one parked and empty vehicle of the following possible types.
-a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
-	"I_G_Offroad_01_repair_F"
-	,"O_MRAP_02_F"
-	,"O_MRAP_02_gmg_F"
-	,"O_MRAP_02_hmg_F"
-	,"O_Truck_02_covered_F"
-	,"O_Truck_02_ammo_F"
-	,"O_Truck_02_box_F"
-	,"I_G_Offroad_01_armed_F"
-	,"I_G_Offroad_01_AT_F"
-	,"I_MRAP_03_hmg_F"
-	,"I_MRAP_03_gmg_F"
-	,"I_G_Offroad_01_F"
-	,"O_Truck_03_device_F"
-	,"O_Truck_03_transport_F"
-	,"O_Truck_03_covered_F"
-	,"O_Truck_03_ammo_F"
-	,"O_Truck_03_fuel_F"
-	,"O_Truck_03_medical_F"
-	,"O_Truck_03_repair_F"];
-	if(Param_UseDLCApex==1) then {
-		a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses pushback "O_LSV_02_unarmed_F";
-		a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses pushback "O_LSV_02_armed_F";
-		a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses pushback "O_LSV_02_AT_F";
-	};
+a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = a3e_arr_ComCenParkedVehicles;
+
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
@@ -592,9 +898,7 @@ a3e_arr_O_pilots = [
 	"O_Pilot_F"
 	,"O_helicrew_F"];
 a3e_arr_I_transport_heli = [
-	"I_Heli_Transport_02_F"
-	,"I_Heli_light_03_F"
-	,"I_Heli_light_03_unarmed_F"];
+	"I_Heli_Transport_02_F"];
 a3e_arr_I_pilots = [
 	"I_helipilot_F"
 	,"I_helicrew_F"];
@@ -612,45 +916,41 @@ a3e_arr_I_pilots = [
 a3e_arr_AmmoDepotBasicWeapons = [];
 // CSAT weapons
 a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_Rook40_F", 50, 4, 8, ["16Rnd_9x21_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["SMG_02_F", 50, 4, 8, ["30Rnd_9x21_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Katiba_F", 100, 2, 4, ["30Rnd_65x39_caseless_green"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Katiba_C_F", 50, 2, 4, ["30Rnd_65x39_caseless_green", "30Rnd_65x39_caseless_green_mag_Tracer"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Katiba_GL_F", 75, 2, 4, ["30Rnd_65x39_caseless_green", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_F", 50, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_GL_F", 50, 2, 4, ["30Rnd_556x45_Stanag", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20C_F", 50, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-// non-CSAT weapons
-a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_P07_F", 10, 4, 8, ["16Rnd_9x21_Mag", "30Rnd_9x21_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_PDW2000_F", 20, 4, 8, ["16Rnd_9x21_Mag", "30Rnd_9x21_Mag"], 6];
 a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_Pistol_heavy_02_F", 10, 4, 8, ["6Rnd_45ACP_Cylinder"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["SMG_02_F", 50, 4, 8, ["30Rnd_9x21_Mag"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Katiba_F", 100, 2, 4, ["30Rnd_65x39_caseless_green", "30Rnd_65x39_caseless_green_mag_Tracer"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Katiba_C_F", 50, 2, 4, ["30Rnd_65x39_caseless_green", "30Rnd_65x39_caseless_green_mag_Tracer"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Katiba_GL_F", 75, 2, 4, ["30Rnd_65x39_caseless_green", "30Rnd_65x39_caseless_green_mag_Tracer", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
+
+// non-CSAT weapons
+a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_PDW2000_F", 20, 4, 8, ["16Rnd_9x21_Mag", "30Rnd_9x21_Mag"], 6];
 a3e_arr_AmmoDepotBasicWeapons pushback ["hgun_ACPC2_F", 20, 4, 8, ["9Rnd_45ACP_Mag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["SMG_01_F", 10, 4, 8, ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_SDAR_F", 10, 2, 4, ["20Rnd_556x45_UW_mag", "30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG20_F", 10, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_F", 10, 2, 4, ["30Rnd_556x45_Stanag"], 6];
-a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_GL_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_F", 50, 2, 4, ["30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow", "30Rnd_556x45_Stanag"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20_GL_F", 50, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 4];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_Mk20C_F", 50, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG20_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow"], 6];
+a3e_arr_AmmoDepotBasicWeapons pushback ["arifle_TRG21_GL_F", 10, 2, 4, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Red", "30Rnd_556x45_Stanag_Tracer_Green", "30Rnd_556x45_Stanag_Tracer_Yellow", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "UGL_FlareWhite_F"], 6];
 
 
 // Weapons and ammo in the special weapons box
 a3e_arr_AmmoDepotSpecialWeapons = [];
 // CSAT weapons
-a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_01_F", 10, 2, 4, ["10Rnd_762x54_Mag"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_EBR_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 9];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_GM6_F", 10, 2, 4, ["5Rnd_127x108_Mag"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_01_DMS_BI_F", 10, 2, 4, ["10Rnd_762x54_Mag"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_GM6_LRPS_F", 10, 1, 2, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], 9];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_GM6_ghex_LRPS_F", 10, 1, 2, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], 9]; 
 a3e_arr_AmmoDepotSpecialWeapons pushback ["LMG_Zafir_F", 50, 2, 4, ["150Rnd_762x54_Box", "150Rnd_762x54_Box_Tracer"], 6];
 if(Param_UseDLCMarksmen==1) then {
 	a3e_arr_AmmoDepotSpecialWeapons pushback ["MMG_01_hex_F", 30, 2, 4, ["150Rnd_93x64_Mag"], 6];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["MMG_02_black_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_06_olive_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 10];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_05_blk_F", 10, 2, 4, ["10Rnd_93x64_DMR_05_Mag"], 12];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_04_F", 10, 2, 4, ["10Rnd_127x54_Mag"], 12];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_03_khaki_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 10];
-	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_02_F", 10, 2, 4, ["10Rnd_338_Mag"], 12];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_04_DMS_F", 10, 2, 4, ["10Rnd_127x54_Mag"], 12];
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_05_KHS_LP_F", 10, 2, 4, ["10Rnd_93x64_DMR_05_Mag"], 12];
 };
 // non-CAST weapons
-//a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_LRR_F", 100, 2, 4, ["7Rnd_408_Mag"], 9];
 a3e_arr_AmmoDepotSpecialWeapons pushback ["LMG_Mk200_F", 20, 2, 4, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], 6];
-
+a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_EBR_MRCO_LP_BI_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 9];
+if(Param_UseDLCMarksmen==1) then {
+	a3e_arr_AmmoDepotSpecialWeapons pushback ["srifle_DMR_06_camo_khs_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 10];
+};
 
 // Weapons and ammo in the launchers box
 a3e_arr_AmmoDepotLaunchers = [];
@@ -664,8 +964,6 @@ a3e_arr_AmmoDepotLaunchers pushback ["launch_NLAW_F", 50, 3, 5, ["NLAW_F"], 3];
 a3e_arr_AmmoDepotLaunchers pushback ["launch_MRAWS_olive_rail_F", 50, 1, 1, ["MRAWS_HEAT_F", "MRAWS_HE_F"], 2];
 //a3e_arr_AmmoDepotLaunchers pushback ["launch_I_Titan_F", 100, 1, 1, ["Titan_AA"], 3];
 //a3e_arr_AmmoDepotLaunchers pushback ["launch_I_Titan_short_F", 100, 1, 1, ["Titan_AP", "Titan_AT"], 3];
-//a3e_arr_AmmoDepotLaunchers pushback ["launch_B_Titan_F", 100, 1, 1, ["Titan_AA"], 3];
-//a3e_arr_AmmoDepotLaunchers pushback ["launch_B_Titan_short_F", 100, 1, 1, ["Titan_AP", "Titan_AT"], 3];
 
 
 // Weapons and ammo in the ordnance box
@@ -673,7 +971,7 @@ a3e_arr_AmmoDepotOrdnance = [];
 // General weapons
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["DemoCharge_Remote_Mag", "SatchelCharge_Remote_Mag"], 5];
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["APERSMine_Range_Mag", "APERSBoundingMine_Range_Mag", "APERSTripMine_Wire_Mag"], 5];
-a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "SLAMDirectionalMine_Wire_Mag"], 5];
+a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["ClaymoreDirectionalMine_Remote_Mag", "SLAMDirectionalMine_Wire_Mag", "ATMine_Range_Mag"], 5];
 a3e_arr_AmmoDepotOrdnance pushback [objNull, 30, 1, 1, ["Laserbatteries"], 5];
 
 // Weapons and ammo in the vehicle box (the big one)
@@ -683,16 +981,14 @@ a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["HandGrenade", "MiniGrena
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["SmokeShell", "SmokeShellYellow", "SmokeShellRed", "SmokeShellGreen", "SmokeShellPurple", "SmokeShellBlue", "SmokeShellOrange"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["Chemlight_blue", "Chemlight_green", "Chemlight_red", "Chemlight_yellow"], 50];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_Smoke_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeOrange_Grenade_shell", "1Rnd_SmokePurple_Grenade_shell", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeYellow_Grenade_shell"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["3Rnd_Smoke_Grenade_shell", "3Rnd_SmokeBlue_Grenade_shell", "3Rnd_SmokeGreen_Grenade_shell", "3Rnd_SmokeOrange_Grenade_shell", "3Rnd_SmokePurple_Grenade_shell", "3Rnd_SmokeRed_Grenade_shell", "3Rnd_SmokeYellow_Grenade_shell"], 5];
 a3e_arr_AmmoDepotVehicle pushback [objNull, 50, 1, 1, ["FlareWhite_F", "FlareGreen_F", "FlareRed_F", "FlareYellow_F"], 25];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["UGL_FlareWhite_F", "UGL_FlareGreen_F", "UGL_FlareRed_F", "UGL_FlareYellow_F", "UGL_FlareCIR_F"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["3Rnd_UGL_FlareWhite_F", "3Rnd_UGL_FlareGreen_F", "3Rnd_UGL_FlareRed_F", "3Rnd_UGL_FlareYellow_F", "3Rnd_UGL_FlareCIR_F"], 5];
-a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_HE_Grenade_shell", "3Rnd_HE_Grenade_shell"], 5];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["UGL_FlareWhite_F", "UGL_FlareGreen_F", "UGL_FlareRed_F", "UGL_FlareYellow_F", "UGL_FlareCIR_F"], 25];
+a3e_arr_AmmoDepotVehicle pushback [objNull, 10, 1, 1, ["1Rnd_HE_Grenade_shell"], 25];
 a3e_arr_AmmoDepotVehicleItems = [];
 a3e_arr_AmmoDepotVehicleItems pushback ["ToolKit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["Medikit", 20, 1, 1, [], 0];
 a3e_arr_AmmoDepotVehicleItems pushback ["FirstAidKit", 100, 10, 50, [], 0];
-a3e_arr_AmmoDepotVehicleBackpacks = ["O_UAV_01_backpack_F"];
+a3e_arr_AmmoDepotVehicleBackpacks = ["B_TacticalPack_ocamo"];
 // Items
 
 // Index 0: Item classname.
@@ -756,16 +1052,15 @@ a3e_arr_AmmoDepotItems pushback ["bipod_03_F_oli", 10, 1, 2];
 // Index 1: Magazine classname.
 // Index 2: Number of magazines.
 a3e_arr_CivilianCarWeapons = [];
-a3e_arr_CivilianCarWeapons pushback ["hgun_P07_F", "16Rnd_9x21_Mag", 5];
-a3e_arr_CivilianCarWeapons pushback ["hgun_P07_snds_F", "30Rnd_9x21_Mag", 11];
-a3e_arr_CivilianCarWeapons pushback ["hgun_Rook40_snds_F", "30Rnd_9x21_Mag", 9];
+a3e_arr_CivilianCarWeapons pushback ["hgun_Rook40_snds_F", "16Rnd_9x21_Mag", 9];
+a3e_arr_CivilianCarWeapons pushback ["hgun_Rook40_F", "16Rnd_9x21_Mag", 9];
 a3e_arr_CivilianCarWeapons pushback ["hgun_ACPC2_F", "9Rnd_45ACP_Mag", 12];
-a3e_arr_CivilianCarWeapons pushback ["arifle_MXM_Hamr_pointer_F", "30Rnd_65x39_caseless_mag_Tracer", 8];
-a3e_arr_CivilianCarWeapons pushback ["arifle_MX_Hamr_pointer_F", "30Rnd_65x39_caseless_mag_Tracer", 6];
-a3e_arr_CivilianCarWeapons pushback ["arifle_MXM_SOS_pointer_F", "30Rnd_65x39_caseless_mag_Tracer", 7];
+a3e_arr_CivilianCarWeapons pushback ["hgun_ACPC2_snds_F", "9Rnd_45ACP_Mag", 12];
+a3e_arr_CivilianCarWeapons pushback ["arifle_Katiba_F", "30Rnd_65x39_caseless_green", 6];
+a3e_arr_CivilianCarWeapons pushback ["arifle_Katiba_GL_F", "UGL_FlareWhite_F", 4];
 a3e_arr_CivilianCarWeapons pushback ["arifle_Katiba_C_F", "30Rnd_65x39_caseless_green", 5];
 a3e_arr_CivilianCarWeapons pushback ["arifle_Mk20_GL_ACO_F", "UGL_FlareWhite_F", 8];
-a3e_arr_CivilianCarWeapons pushback ["SMG_01_Holo_F", "30Rnd_45ACP_Mag_SMG_01_Tracer_Green", 5];
+a3e_arr_CivilianCarWeapons pushback ["arifle_TRG21_F", "30Rnd_556x45_Stanag", 6];
 a3e_arr_CivilianCarWeapons pushback ["SMG_02_ACO_F", "30Rnd_9x21_Mag", 12];
 if(Param_UseDLCMarksmen==1) then {
 	a3e_arr_CivilianCarWeapons pushback ["srifle_DMR_06_camo_khs_F", "20Rnd_762x51_Mag", 8];
@@ -826,8 +1121,7 @@ a3e_arr_Bipods = [
 // Helicopters that come to pick you up
 //////////////////////////////////////////////////////////////////
 a3e_arr_extraction_chopper = [
-	"B_Heli_Transport_01_F"
-	,"B_Heli_Transport_01_F"];
+	"B_Heli_Transport_01_F"];
 	if(Param_UseDLCHelis==1) then {
 	a3e_arr_extraction_chopper pushback "B_Heli_Transport_03_F";
 	};
@@ -959,23 +1253,30 @@ a3e_arr_CrashSiteCrew = [
 	"B_Pilot_F"
 	,"B_helicrew_F"];
 a3e_arr_CrashSiteWrecksCar = [
-	"Land_Wreck_HMMWV_F"
-	,"Land_Wreck_Hunter_F"
+	"Land_Wreck_Hunter_F"
 	,"Land_Wreck_Slammer_F"
 	,"Land_Wreck_AFV_Wheeled_01_F"];
 a3e_arr_CrashSiteCrewCar = [
-	"B_Soldier_lite_F"];
+	"B_crew_F"];
 // Weapons and ammo in crash site box
 a3e_arr_CrashSiteWeapons = [];
 a3e_arr_CrashSiteWeapons pushback ["launch_NLAW_F", 10, 1, 2, ["NLAW_F"], 3];
 a3e_arr_CrashSiteWeapons pushback ["launch_MRAWS_sand_F", 10, 1, 2, ["MRAWS_HEAT_F","MRAWS_HE_F"], 2];
-a3e_arr_CrashSiteWeapons pushback ["srifle_EBR_F", 10, 1, 2, ["20Rnd_762x51_Mag"], 8];
-a3e_arr_CrashSiteWeapons pushback ["srifle_LRR_F", 10, 1, 2, ["7Rnd_408_Mag"], 8];
+a3e_arr_CrashSiteWeapons pushback ["srifle_EBR_DMS_F", 10, 1, 2, ["20Rnd_762x51_Mag"], 8];
+a3e_arr_CrashSiteWeapons pushback ["srifle_LRR_LRPS_F", 10, 1, 2, ["7Rnd_408_Mag"], 8];
 a3e_arr_CrashSiteWeapons pushback ["arifle_MX_F", 75, 2, 4, ["30Rnd_65x39_caseless_mag"], 6];
 a3e_arr_CrashSiteWeapons pushback ["arifle_MX_GL_F", 50, 2, 4, ["30Rnd_65x39_caseless_mag", "1Rnd_HE_Grenade_shell", "UGL_FlareGreen_F"], 6];
 a3e_arr_CrashSiteWeapons pushback ["arifle_MX_SW_F", 20, 1, 2, ["100Rnd_65x39_caseless_mag_Tracer"], 6];
 a3e_arr_CrashSiteWeapons pushback ["arifle_MXM_F", 10, 1, 2, ["30Rnd_65x39_caseless_mag"], 8];
-a3e_arr_CrashSiteWeapons pushback ["SMG_01_Holo_pointer_snds_F", 10, 1, 2, ["30Rnd_45ACP_Mag_SMG_01"], 8];
+a3e_arr_CrashSiteWeapons pushback ["SMG_01_Holo_pointer_snds_F", 50, 1, 2, ["30Rnd_45ACP_Mag_SMG_01"], 8];
+if(Param_UseDLCMarksmen==1) then {
+	a3e_arr_CrashSiteWeapons pushback ["MMG_02_sand_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
+	a3e_arr_CrashSiteWeapons pushback ["MMG_02_camo_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
+	a3e_arr_CrashSiteWeapons pushback ["MMG_02_black_F", 10, 2, 4, ["130Rnd_338_Mag"], 6];
+	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_02_camo_AMS_LP_F", 30, 2, 4, ["10Rnd_338_Mag"], 10];
+	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_02_sniper_AMS_LP_S_F", 10, 2, 4, ["10Rnd_338_Mag"], 10];
+	a3e_arr_CrashSiteWeapons pushback ["srifle_DMR_03_AMS_F", 10, 2, 4, ["20Rnd_762x51_Mag"], 12];
+};
 // Attachments and other items in crash site box
 a3e_arr_CrashSiteItems = [];
 a3e_arr_CrashSiteItems pushback ["optic_Hamr", 10, 1, 3];
@@ -984,3 +1285,4 @@ a3e_arr_CrashSiteItems pushback ["optic_Aco_smg", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["optic_Holosight", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["optic_SOS", 10, 1, 3];
 a3e_arr_CrashSiteItems pushback ["muzzle_snds_H", 10, 1, 3];
+a3e_arr_CrashSiteItems pushback ["B_UavTerminal", 50, 1, 1];


### PR DESCRIPTION
Includes a complete rework of Vanilla, Vanilla US, CUP Taki, CUP-CDF winter, and I also added some adjustments to CUP RU vs USMC-RACS.

I've adjusted this in line with my new RU vs USMC and RACS version so they all have new weapons, units, and vehicles that have been added to the mods and the base game over the years and they have the new ratio for vehicle spawns that seems to be working pretty well.  I made sure to keep the low SMG count in the prison backpack that's currently in place for all versions.