### PR TITLE
Add selectRandomWeightedFromSet function

### DIFF
--- a/Code/Scripts/Escape/CreateCivilEnemy.sqf
+++ b/Code/Scripts/Escape/CreateCivilEnemy.sqf
@@ -12,7 +12,7 @@ _unitTypes = _this select 4;
 _enemyFrequency = _this select 5;
 if (count _this > 6) then {_debug = _this select 6;} else {_debug = false;};
 
-_vehicleClass = selectRandom _vehicleTypes;
+_vehicleClass = _vehicleTypes call A3E_fnc_selectRandomWeightedFromSet;
 _vehicle = createVehicle [_vehicleClass, _spawnPos, [], 0, "NONE"];
 
 // Find a free vehicle variable name

--- a/Code/Scripts/Escape/CreateMotorizedSearchGroup.sqf
+++ b/Code/Scripts/Escape/CreateMotorizedSearchGroup.sqf
@@ -11,7 +11,7 @@ if (count _this > 4) then {_maxSkill = _this select 4;} else {_maxSkill = 0.6;};
 if (count _this > 5) then {_debug = _this select 5;} else {_debug = false;};
 
 // Vehicle classes have following cargo capacity [7, 5, 7, 10]
-_vehicleClass = selectRandom a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses;
+_vehicleClass = a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 
 _vehicleMaxCargo = (configfile >> "CfgVehicles" >> _vehicleClass >>  "transportSoldier") call BIS_fnc_getCfgData;
 
@@ -46,7 +46,7 @@ if (_enemyFrequency == 2) then {
 
 _infantryTypes = a3e_arr_Escape_InfantryTypes;
 for "_i" from 1 to _soldiersCount do {
-    _infantryType = selectRandom _infantryTypes;
+    _infantryType = _infantryTypes call A3E_fnc_selectRandomWeightedFromSet;
     _insurgentSoldier = _group createUnit [_infantryType, [0,0,30], [], 0, "FORM"];
     //_insurgentSoldier setSkill (_minSkill + random (_maxSkill - _minSkill));
 //	[_insurgentsoldier, a3e_var_Escape_enemyMinSkill] call EGG_EVO_skill;

--- a/Code/Scripts/Escape/CreateReinforcementTruck.sqf
+++ b/Code/Scripts/Escape/CreateReinforcementTruck.sqf
@@ -10,7 +10,7 @@ if (count _this > 2) then {_maxSkill = _this select 2;} else {_maxSkill = 0.6;};
 if (count _this > 3) then {_enemyFrequency = _this select 3;} else {_enemyFrequency = 3;};
 if (count _this > 4) then {_debug = _this select 4;} else {_debug = false;};
 
-_vehicleClass = selectRandom a3e_arr_Escape_ReinforcementTruck_vehicleClasses;
+_vehicleClass = a3e_arr_Escape_ReinforcementTruck_vehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 
 _vehicleMaxCargo = (configfile >> "CfgVehicles" >> _vehicleClass >>  "transportSoldier") call BIS_fnc_getCfgData;
 
@@ -54,7 +54,7 @@ if (_soldiersCount > _vehicleMaxCargo) then {
 };
 
 for "_i" from 1 to _soldiersCount do {
-    _infantryType = selectRandom a3e_arr_Escape_InfantryTypes;
+    _infantryType = a3e_arr_Escape_InfantryTypes call A3E_fnc_selectRandomWeightedFromSet;
     _insurgentSoldier = _cargoGroup createUnit [_infantryType, [0,0,30], [], 0, "FORM"];
     //_insurgentSoldier setSkill (_minSkill + random (_maxSkill - _minSkill));
 	//[_insurgentSoldier, a3e_var_Escape_enemyMinSkill] call EGG_EVO_skill;

--- a/Code/Scripts/Escape/CreateSearchChopper.sqf
+++ b/Code/Scripts/Escape/CreateSearchChopper.sqf
@@ -46,7 +46,7 @@ while {!(isNil _vehicleVarName)} do {
 
 //_chopper = "O_Heli_Light_02_F" createVehicle _homePos;
 //_chopper = createVehicle ["RHS_Mi8AMTSh_vvsc", _homePos, [], 0, "NONE"];
-private _type =  selectRandom a3e_arr_searchChopper;
+private _type = a3e_arr_searchChopper call A3E_fnc_selectRandomWeightedFromSet;
 
 _homePos = _homePos vectorAdd [0,0,100];
 

--- a/Code/Scripts/Escape/EscapeSurprises.sqf
+++ b/Code/Scripts/Escape/EscapeSurprises.sqf
@@ -144,7 +144,7 @@ while {true} do {
                     _dropUnits = [];
                     
                     for [{_i = 0}, {_i < _noOfDropUnits}, {_i = _i + 1}] do {
-                        _soldierType = A3E_arr_recon_InfantryTypes select floor (random count A3E_arr_recon_InfantryTypes);
+                        _soldierType = A3E_arr_recon_InfantryTypes call A3E_fnc_selectRandomWeightedFromSet;
                         _soldier = _dropGroup createUnit [_soldierType, [0,0,30], [], 0, "FORM"];
                         //_soldier setSkill (_minEnemySkill + random (_maxEnemySkill - _minEnemySkill));
 						//[_soldier, a3e_var_Escape_enemyMinSkill] call EGG_EVO_skill;
@@ -164,8 +164,8 @@ while {true} do {
                         //[_group, drn_searchAreaMarkerName, _dropPos, a3e_var_Escape_DebugSearchGroup] execVM "Scripts\DRN\SearchGroup\SearchGroup.sqf";
                         [_group, drn_searchAreaMarkerName, _dropPos, A3E_Debug] spawn DRN_fnc_SearchGroup;
                     };
-                    _helitype = a3e_arr_O_transport_heli select floor(random(count(a3e_arr_O_transport_heli)));
-					_crewtype = a3e_arr_O_pilots select floor(random(count(a3e_arr_O_pilots)));
+                    _helitype = a3e_arr_O_transport_heli call A3E_fnc_selectRandomWeightedFromSet;
+					_crewtype = a3e_arr_O_pilots call A3E_fnc_selectRandomWeightedFromSet;
                     [getMarkerPos "drn_dropChopperStartPosMarker", A3E_VAR_Side_Opfor, _helitype, _crewtype, _dropUnits, _dropPosition, _minEnemySkill, _maxEnemySkill, _onGroupDropped, A3E_Debug] execVM "Scripts\Escape\CreateDropChopper.sqf";
                     
                     // Create next drop chopper
@@ -189,7 +189,7 @@ while {true} do {
                     _dropUnits = [];
                     
                     for [{_i = 0}, {_i < _noOfDropUnits}, {_i = _i + 1}] do {
-                        _soldierType = a3e_arr_Escape_InfantryTypes_Ind select floor (random count a3e_arr_Escape_InfantryTypes_Ind);
+                        _soldierType = a3e_arr_Escape_InfantryTypes_Ind call A3E_fnc_selectRandomWeightedFromSet;
                         _soldier = _dropGroup createUnit [_soldierType, [0,0,30], [], 0, "FORM"];
                         //_soldier setSkill (_minEnemySkill + random (_maxEnemySkill - _minEnemySkill));
 						//[_soldier, a3e_var_Escape_enemyMinSkill] call EGG_EVO_skill;
@@ -209,8 +209,8 @@ while {true} do {
                         //[_group, drn_searchAreaMarkerName, _dropPos, a3e_var_Escape_DebugSearchGroup] execVM "Scripts\DRN\SearchGroup\SearchGroup.sqf";
                         [_group, drn_searchAreaMarkerName, _dropPos, A3E_Debug] spawn DRN_fnc_SearchGroup;
                     };
-                    _helitype = a3e_arr_I_transport_heli select floor(random(count(a3e_arr_I_transport_heli)));
-					_crewtype = a3e_arr_I_pilots select floor(random(count(a3e_arr_I_pilots)));
+                    _helitype = a3e_arr_I_transport_heli call A3E_fnc_selectRandomWeightedFromSet;
+					_crewtype = a3e_arr_I_pilots call A3E_fnc_selectRandomWeightedFromSet;
                     [getMarkerPos "drn_dropChopperStartPosMarker", A3E_VAR_Side_Ind, _helitype, _crewtype, _dropUnits, _dropPosition, _minEnemySkill, _maxEnemySkill, _onGroupDropped, A3E_Debug] execVM "Scripts\Escape\CreateDropChopper.sqf";
                     
                     // Create next drop chopper
@@ -225,8 +225,8 @@ while {true} do {
 				
                 if (_surpriseID == "RUSSIANSEARCHCHOPPER") then {
                     private ["_chopper", "_result", "_group","_helitype","_crewtype"];
-                    _helitype = a3e_arr_O_attack_heli select floor(random(count(a3e_arr_O_attack_heli)));
-					_crewtype = a3e_arr_O_pilots select floor(random(count(a3e_arr_O_pilots)));
+                    _helitype = a3e_arr_O_attack_heli call A3E_fnc_selectRandomWeightedFromSet;
+					_crewtype = a3e_arr_O_pilots call A3E_fnc_selectRandomWeightedFromSet;
                     //_chopper = "O_Heli_Light_02_F" createVehicle getMarkerPos "drn_russianSearchChopperStartPosMarker";
                     _chopper = createVehicle [_helitype, (getMarkerPos "drn_russianSearchChopperStartPosMarker"), [], 0, "FLY"];
                     _chopper lock false;
@@ -267,7 +267,7 @@ while {true} do {
 				if (_surpriseID == "SEARCHDRONE") then {
                     private ["_chopper", "_result"];
 
-					_chopper = createVehicle [selectRandom a3e_arr_searchdrone, getMarkerPos "drn_russianSearchChopperStartPosMarker", [], random 360, "FLY"];
+					_chopper = createVehicle [a3e_arr_searchdrone call A3E_fnc_selectRandomWeightedFromSet, getMarkerPos "drn_russianSearchChopperStartPosMarker", [], random 360, "FLY"];
 					createVehicleCrew _chopper;
 					
 					_chopper lock false;

--- a/Code/Scripts/Escape/Functions.sqf
+++ b/Code/Scripts/Escape/Functions.sqf
@@ -49,7 +49,7 @@ drn_fnc_Escape_OnSpawnGeneralSoldierUnit = {
 			if(_nighttime) then {
 				_scopes = _scopes + A3E_arr_NightScopes;
 			};
-			_scope = selectRandom _scopes;
+			_scope = _scopes call A3E_fnc_selectRandomWeightedFromSet;
 			_this addPrimaryWeaponItem _scope;
 		};
 	};
@@ -79,7 +79,7 @@ drn_fnc_Escape_OnSpawnGeneralSoldierUnit = {
 	
 	//Bipod chance
 	if((random 100 < 20)) then {
-		_this addPrimaryWeaponItem (selectRandom a3e_arr_Bipods);
+		_this addPrimaryWeaponItem (a3e_arr_Bipods call A3E_fnc_selectRandomWeightedFromSet);
 	};
 	
 	//Chance for silencers
@@ -584,15 +584,15 @@ drn_fnc_Escape_InitializeComCenArmor = {
         {
             case 1:
             {
-                a3e_arr_Escape_ComCenArmors set [count a3e_arr_Escape_ComCenArmors, [_pos, [selectRandom a3e_arr_ComCenDefence_lightArmorClasses], []]];
+                a3e_arr_Escape_ComCenArmors set [count a3e_arr_Escape_ComCenArmors, [_pos, [a3e_arr_ComCenDefence_lightArmorClasses call A3E_fnc_selectRandomWeightedFromSet], []]];
             };
             case 2:
             {
-                a3e_arr_Escape_ComCenArmors set [count a3e_arr_Escape_ComCenArmors, [_pos, [selectRandom a3e_arr_ComCenDefence_heavyArmorClasses], []]];
+                a3e_arr_Escape_ComCenArmors set [count a3e_arr_Escape_ComCenArmors, [_pos, [a3e_arr_ComCenDefence_heavyArmorClasses call A3E_fnc_selectRandomWeightedFromSet], []]];
             };
             default
             {
-                a3e_arr_Escape_ComCenArmors set [count a3e_arr_Escape_ComCenArmors, [_pos, [selectRandom a3e_arr_ComCenDefence_lightArmorClasses, selectRandom a3e_arr_ComCenDefence_heavyArmorClasses], []]];
+                a3e_arr_Escape_ComCenArmors set [count a3e_arr_Escape_ComCenArmors, [_pos, [a3e_arr_ComCenDefence_lightArmorClasses call A3E_fnc_selectRandomWeightedFromSet, a3e_arr_ComCenDefence_heavyArmorClasses call A3E_fnc_selectRandomWeightedFromSet], []]];
             };
         };
         
@@ -625,7 +625,7 @@ drn_fnc_Escape_PopulateVehicle = {
     // Driver
     _continue = true;
     while {_continue && (_soldierCount <= _maxSoldiersCount)} do {
-        _unitType = selectRandom _unitTypes;
+        _unitType = _unitTypes call A3E_fnc_selectRandomWeightedFromSet;
         _insurgentSoldier = _group createUnit [_unitType, [0,0,0], [], 0, "FORM"];
         
         _insurgentSoldier setRank "LIEUTENANT";
@@ -644,7 +644,7 @@ drn_fnc_Escape_PopulateVehicle = {
     // Gunner
     _continue = true;
     while {_continue && _soldierCount <= _maxSoldiersCount} do {
-        _unitType = selectRandom _unitTypes;
+        _unitType = _unitTypes call A3E_fnc_selectRandomWeightedFromSet;
         _insurgentSoldier = _group createUnit [_unitType, [0,0,0], [], 0, "FORM"];
         
         _insurgentSoldier setRank "LIEUTENANT";
@@ -663,7 +663,7 @@ drn_fnc_Escape_PopulateVehicle = {
     // Commander
     _continue = true;
     while {_continue && _soldierCount <= _maxSoldiersCount} do {
-        _unitType = selectRandom _unitTypes;
+        _unitType = _unitTypes call A3E_fnc_selectRandomWeightedFromSet;
         _insurgentSoldier = _group createUnit [_unitType, [0,0,0], [], 0, "FORM"];
         
         _insurgentSoldier setRank "LIEUTENANT";
@@ -682,7 +682,7 @@ drn_fnc_Escape_PopulateVehicle = {
     // Cargo
     _continue = true;
     while {_continue && _soldierCount <= _maxSoldiersCount} do {
-        _unitType = selectRandom _unitTypes;
+        _unitType = _unitTypes call A3E_fnc_selectRandomWeightedFromSet;
         _insurgentSoldier = _group createUnit [_unitType, [0,0,0], [], 0, "FORM"];
         
         _insurgentSoldier setRank "LIEUTENANT";

--- a/Code/functions/AI/fn_AddStaticGunner.sqf
+++ b/Code/functions/AI/fn_AddStaticGunner.sqf
@@ -9,7 +9,7 @@ switch (_side) do {
     case A3E_VAR_Side_Ind: {_possibleInfantryTypes = a3e_arr_Escape_InfantryTypes_Ind;};
 };
 if(!(isNull _static)) then {
-	_infantryType = _possibleInfantryTypes select floor (random count _possibleInfantryTypes);
+	_infantryType = _possibleInfantryTypes call A3E_fnc_selectRandomWeightedFromSet;
 	_unit = _group createUnit [_infantryType, getpos _static, [], 0, "FORM"];    
 	_unit assignAsGunner _static;
 	_unit moveInGunner _static;

--- a/Code/functions/AI/fn_CallCAS.sqf
+++ b/Code/functions/AI/fn_CallCAS.sqf
@@ -7,7 +7,7 @@ diag_log ("Calling CAS to "+ str _position);
 
 _cas = "Logic" createVehicleLocal getpos player;
 _cas setDir (random 360);
-_cas setVariable ["vehicle",selectRandom a3e_arr_CASplane];
+_cas setVariable ["vehicle", a3e_arr_CASplane call A3E_fnc_selectRandomWeightedFromSet];
  //0=guns	1=missiles	2=both, 3=bomb
 _cas setVariable ["type", selectRandom[0,0,1,2,3]];
 

--- a/Code/functions/Common/fn_selectRandomWeightedFromSet.sqf
+++ b/Code/functions/Common/fn_selectRandomWeightedFromSet.sqf
@@ -1,0 +1,19 @@
+
+private _weightedArray = [];
+{
+    _x params ["_value", ["_weight", 1]];
+    if !(_weight isEqualType 0) then {
+        _value = _x;
+        _weight = 1;
+    };
+    _weightedArray append [_value, _weight];
+} forEach _this;
+
+private _result = selectRandomWeighted _weightedArray;
+
+if (_result isEqualType []) exitWith {
+    // call recursively
+    _result call A3E_fnc_selectRandomWeightedFromSet
+};
+
+_result

--- a/Code/functions/DRN/fn_AmbientInfantry.sqf
+++ b/Code/functions/DRN/fn_AmbientInfantry.sqf
@@ -124,7 +124,7 @@ while {true} do {
         _group = createGroup _faction;
         
         for [{_i = 0}, {_i < _unitsInGroup}, {_i = _i + 1}] do {
-            _infantryType = _possibleInfantryTypes select floor (random count _possibleInfantryTypes);
+            _infantryType = _possibleInfantryTypes call A3E_fnc_selectRandomWeightedFromSet;
             //_infantryType createUnit [_spawnPos, _group,"", _skill, "PRIVATE"];
 			_group createUnit [_infantryType, _spawnPos, [], 0, "FORM"];
         };

--- a/Code/functions/DRN/fn_GarrisonUnits.sqf
+++ b/Code/functions/DRN/fn_GarrisonUnits.sqf
@@ -10,7 +10,7 @@ _watchtower1 = _locationPos nearObjects ["Land_Cargo_Patrol_V1_F", 50];
 {
 	_group = createGroup _side;
 	_spawnPos = [_markerName] call drn_fnc_CL_GetRandomMarkerPos;
-	_soldier = _group createUnit [selectRandom _soldierType, _spawnPos, [], 0, "FORM"];
+	_soldier = _group createUnit [_soldierType call A3E_fnc_selectRandomWeightedFromSet, _spawnPos, [], 0, "FORM"];
 	_soldier call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 	_house1 = selectRandom _watchtower1;
 	_bpos = _house1 buildingPos -1;
@@ -26,7 +26,7 @@ _bunker1 = _locationPos nearObjects ["Land_Cargo_HQ_V1_F", 50];
 	for [{_i=0},{_i<=(floor (random _amountofunits))},{_i=_i+1}] do {
 		_group = createGroup _side;
 		_spawnPos = [_markerName] call drn_fnc_CL_GetRandomMarkerPos;
-		_soldier = _group createUnit [selectRandom _soldierType, _spawnPos, [], 0, "FORM"];
+		_soldier = _group createUnit [_soldierType call A3E_fnc_selectRandomWeightedFromSet, _spawnPos, [], 0, "FORM"];
 		_soldier call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 		_house1 = selectRandom _bunker1;
 		_bpos = _house1 buildingPos -1;
@@ -43,7 +43,7 @@ _tower1 = _locationPos nearObjects ["Land_Cargo_Tower_V1_F", 50];
 	for [{_i=0},{_i<=(floor (random _amountofunits))},{_i=_i+1}] do {
 		_group = createGroup _side;
 		_spawnPos = [_markerName] call drn_fnc_CL_GetRandomMarkerPos;
-		_soldier = _group createUnit [selectRandom _soldierType, _spawnPos, [], 0, "FORM"];
+		_soldier = _group createUnit [_soldierType call A3E_fnc_selectRandomWeightedFromSet, _spawnPos, [], 0, "FORM"];
 		_soldier call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 		_house1 = selectRandom _tower1;
 		_bpos = _house1 buildingPos -1;
@@ -60,7 +60,7 @@ _bunker2 = _locationPos nearObjects ["Land_Bunker_01_HQ_F", 50];
 	for [{_i=0},{_i<=(floor (random _amountofunits))},{_i=_i+1}] do {
 		_group = createGroup _side;
 		_spawnPos = [_markerName] call drn_fnc_CL_GetRandomMarkerPos;
-		_soldier = _group createUnit [selectRandom _soldierType, _spawnPos, [], 0, "FORM"];
+		_soldier = _group createUnit [_soldierType call A3E_fnc_selectRandomWeightedFromSet, _spawnPos, [], 0, "FORM"];
 		_soldier call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 		_house1 = selectRandom _bunker2;
 		_bpos = _house1 buildingPos -1;
@@ -77,7 +77,7 @@ _bunker3 = _locationPos nearObjects ["Land_Bunker_01_small_F", 50];
 	for [{_i=0},{_i<=(floor (random _amountofunits))},{_i=_i+1}] do {
 		_group = createGroup _side;
 		_spawnPos = [_markerName] call drn_fnc_CL_GetRandomMarkerPos;
-		_soldier = _group createUnit [selectRandom _soldierType, _spawnPos, [], 0, "FORM"];
+		_soldier = _group createUnit [_soldierType call A3E_fnc_selectRandomWeightedFromSet, _spawnPos, [], 0, "FORM"];
 		_soldier call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 		_house1 = selectRandom _bunker3;
 		_bpos = _house1 buildingPos -1;
@@ -94,7 +94,7 @@ _bunker4 = _locationPos nearObjects ["Land_Bunker_01_tall_F", 50];
 	for [{_i=0},{_i<=(floor (random _amountofunits))},{_i=_i+1}] do {
 		_group = createGroup _side;
 		_spawnPos = [_markerName] call drn_fnc_CL_GetRandomMarkerPos;
-		_soldier = _group createUnit [selectRandom _soldierType, _spawnPos, [], 0, "FORM"];
+		_soldier = _group createUnit [_soldierType call A3E_fnc_selectRandomWeightedFromSet, _spawnPos, [], 0, "FORM"];
 		_soldier call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 		_house1 = selectRandom _bunker4;
 		_bpos = _house1 buildingPos -1;

--- a/Code/functions/DRN/fn_InitGuardedLocations.sqf
+++ b/Code/functions/DRN/fn_InitGuardedLocations.sqf
@@ -78,7 +78,7 @@ while {_locationExists} do {
     
 	_soldiers = [];
 	for [{_i = 0}, {_i < _soldierCount}, {_i = _i + 1}] do {
-		_soldierType = _possibleInfantryTypes select (floor (random (count _possibleInfantryTypes)));
+		_soldierType = _possibleInfantryTypes call A3E_fnc_selectRandomWeightedFromSet;
 
 		// soldier: [type, skill, spawned, damage, obj, scriptHandle, hasScript]
 		_soldier = [_soldierType, (_minSkill + random (_maxSkill - _minSkill)), false, 0, objNull, objNull, false];

--- a/Code/functions/DRN/fn_MilitaryTraffic.sqf
+++ b/Code/functions/DRN/fn_MilitaryTraffic.sqf
@@ -306,7 +306,7 @@ while {true} do {
 			if(_side == civilian) then {
                 _possibleVehicles = a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses;
             };
-            _vehicleType = _possibleVehicles select floor (random count _possibleVehicles);
+            _vehicleType = _possibleVehicles call A3E_fnc_selectRandomWeightedFromSet;
             _result = [_pos, _direction + 90, _vehicleType, _side] call BIS_fnc_spawnVehicle;
             _vehicle = _result select 0;
 			[_vehicle] call a3e_fnc_onVehicleSpawn;

--- a/Code/functions/DRN/fn_PopulateAquaticPatrol.sqf
+++ b/Code/functions/DRN/fn_PopulateAquaticPatrol.sqf
@@ -25,7 +25,7 @@ for [{_i=0},{_i<=_groups},{_i=_i+1}] do {
 		_spawnPos = [_markerName] call a3e_fnc_RandomMarkerPos;
 	};
 	
-	_boat = [_spawnPos, random 360, (a3e_arr_AquaticPatrols select floor (random count a3e_arr_AquaticPatrols)), A3E_VAR_Side_Opfor] call BIS_fnc_spawnVehicle;
+	_boat = [_spawnPos, random 360, a3e_arr_AquaticPatrols call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Opfor] call BIS_fnc_spawnVehicle;
 	_arrBoats set [count _arrBoats, _boat];
 	[_boat select 0] call a3e_fnc_onVehicleSpawn;
 	_crew = _boat select 1;

--- a/Code/functions/Server/fn_RoadBlocks.sqf
+++ b/Code/functions/Server/fn_RoadBlocks.sqf
@@ -98,7 +98,7 @@ _fnc_CreateRoadBlock = {
     };
 		
 	
-    private _result = [_pos, _dir, selectRandom _possibleVehicles, _side] call BIS_fnc_spawnVehicle;
+    private _result = [_pos, _dir, _possibleVehicles call A3E_fnc_selectRandomWeightedFromSet, _side] call BIS_fnc_spawnVehicle;
     private _vehicle = _result select 0;
 	[_vehicle] call a3e_fnc_onVehicleSpawn;
     private _crew = _result select 1;
@@ -109,7 +109,7 @@ _fnc_CreateRoadBlock = {
 	
 	_result spawn _fnc_OnSpawnMannedVehicle;
 	
-    private _gun = selectRandom a3e_arr_ComCenStaticWeapons;
+    private _gun = a3e_arr_ComCenStaticWeapons call A3E_fnc_selectRandomWeightedFromSet;
    // private _static = [_gun, (_pos vectoradd [10,0,0]), _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	private _static = createVehicle [_gun, (_pos vectoradd [10,0,0]), [], 0, "NONE"];
 	[_static] call a3e_fnc_onVehicleSpawn;
@@ -127,10 +127,10 @@ _fnc_CreateRoadBlock = {
         _guardTypes = a3e_arr_Escape_InfantryTypes_Ind;
     };
     
-    _group createUnit [selectRandom _guardTypes, _pos, [], 0, "FORM"];
-    _group createUnit [selectRandom _guardTypes, _pos, [], 0, "FORM"];
-    _group createUnit [selectRandom _guardTypes, _pos, [], 0, "FORM"];
-    _group createUnit [selectRandom _guardTypes, _pos, [], 0, "FORM"];
+    _group createUnit [_guardTypes call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
+    _group createUnit [_guardTypes call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
+    _group createUnit [_guardTypes call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
+    _group createUnit [_guardTypes call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
     
     {
         _x setUnitRank "LIEUTENANT";

--- a/Code/functions/Server/fn_RunExtraction - Kopie.sqf
+++ b/Code/functions/Server/fn_RunExtraction - Kopie.sqf
@@ -9,7 +9,7 @@ private _extractionMarkerName = "A3E_ExtractionPos" + str _extractionPointNo;
 //_extractionMarkerName2 = "A3E_ExtractionPos" + str _extractionPointNo + "_1";
 
 private _dir = (getMarkerPos _spawnMarkerName) getDir (getMarkerPos _extractionMarkerName);
-private _result = [[((getMarkerPos _spawnMarkerName) select 0) + 80, ((getMarkerPos _spawnMarkerName) select 1), 50],_dir, (a3e_arr_extraction_chopper select floor (random count a3e_arr_extraction_chopper)), A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+private _result = [[((getMarkerPos _spawnMarkerName) select 0) + 80, ((getMarkerPos _spawnMarkerName) select 1), 50],_dir, a3e_arr_extraction_chopper call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 private _boat1 = _result select 0;
 private _group1 = _result select 2;
 
@@ -21,7 +21,7 @@ _waypoint setWaypointStatements ["true", ""];
 
 sleep 5;
 
-_result = [[((getMarkerPos _spawnMarkerName) select 0), ((getMarkerPos _spawnMarkerName) select 1) + 80, 200], _dir, (a3e_arr_extraction_chopper_escort select floor (random count a3e_arr_extraction_chopper_escort)), A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [[((getMarkerPos _spawnMarkerName) select 0), ((getMarkerPos _spawnMarkerName) select 1) + 80, 200], _dir, a3e_arr_extraction_chopper_escort call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 private _boat3 = _result select 0;
 private _group3 = _result select 2;
 
@@ -34,7 +34,7 @@ _waypoint setWaypointLoiterRadius 100;
 
 sleep 5;
 
-_result = [[((getMarkerPos _spawnMarkerName) select 0) - 80, ((getMarkerPos _spawnMarkerName) select 1), 100], _dir, (a3e_arr_extraction_chopper select floor (random count a3e_arr_extraction_chopper)), A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [[((getMarkerPos _spawnMarkerName) select 0) - 80, ((getMarkerPos _spawnMarkerName) select 1), 100], _dir, a3e_arr_extraction_chopper call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 private _boat2 = _result select 0;
 private _group2 = _result select 2;
 

--- a/Code/functions/Server/fn_RunExtraction.sqf
+++ b/Code/functions/Server/fn_RunExtraction.sqf
@@ -11,18 +11,18 @@ _extractionMarkerName2 = "A3E_ExtractionPos" + str _extractionPointNo + "_1";
 private _spawnVector = (getMarkerPos _spawnMarkerName) vectorDiff (getMarkerPos _extractionMarkerName);
 private _dir = (getMarkerPos _spawnMarkerName) getDir (getMarkerPos _extractionMarkerName);
 private _pos = ((getMarkerPos _extractionMarkerName) vectorAdd _spawnVector) vectorAdd [0,0,40];
-private _result = [_pos,_dir, selectRandom a3e_arr_extraction_chopper, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+private _result = [_pos,_dir, a3e_arr_extraction_chopper call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 private _boat1 = _result select 0;
 private _group1 = _result select 2;
 
 
 _pos = ((getMarkerPos _extractionMarkerName2) vectorAdd (_spawnVector vectorMultiply 1.2)) vectorAdd [0,0,40];
-_result = [_pos,_dir, selectRandom a3e_arr_extraction_chopper, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [_pos,_dir, a3e_arr_extraction_chopper call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 private _boat2 = _result select 0;
 private _group2 = _result select 2;
 
 _pos = ((getMarkerPos _extractionMarkerName) vectorAdd (_spawnVector vectorMultiply 0.8)) vectorAdd [0,0,60];
-_result = [_pos,_dir, selectRandom a3e_arr_extraction_chopper_escort, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [_pos,_dir, a3e_arr_extraction_chopper_escort call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 private _boat3 = _result select 0;
 private _group3 = _result select 2;
 

--- a/Code/functions/Server/fn_RunExtractionBoat.sqf
+++ b/Code/functions/Server/fn_RunExtractionBoat.sqf
@@ -9,7 +9,7 @@ _extractionMarkerName = "A3E_ExtractionPos" + str _extractionPointNo;
 _extractionMarkerName2 = "A3E_ExtractionPos" + str _extractionPointNo + "_1";
 
 private _dir = (getMarkerPos _spawnMarkerName) getDir (getMarkerPos _extractionMarkerName);
-_result = [[((getMarkerPos _spawnMarkerName) select 0) + 80, ((getMarkerPos _spawnMarkerName) select 1), 0],_dir, (a3e_arr_extraction_boat select floor (random count a3e_arr_extraction_boat)), A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [[((getMarkerPos _spawnMarkerName) select 0) + 80, ((getMarkerPos _spawnMarkerName) select 1), 0],_dir, a3e_arr_extraction_boat call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 _boat1 = _result select 0;
 _group1 = _result select 2;
 
@@ -21,7 +21,7 @@ _waypoint setWaypointStatements ["true", "vehicle this land 'GET IN'"];
 
 sleep 1;
 
-_result = [[((getMarkerPos _spawnMarkerName) select 0), ((getMarkerPos _spawnMarkerName) select 1) + 80, 0], _dir, (a3e_arr_extraction_boat_escort select floor (random count a3e_arr_extraction_boat_escort)), A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [[((getMarkerPos _spawnMarkerName) select 0), ((getMarkerPos _spawnMarkerName) select 1) + 80, 0], _dir, a3e_arr_extraction_boat_escort call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 _boat3 = _result select 0;
 _group3 = _result select 2;
 
@@ -34,7 +34,7 @@ _waypoint setWaypointFormation "WEDGE";
 
 sleep 1;
 
-_result = [[((getMarkerPos _spawnMarkerName) select 0) - 80, ((getMarkerPos _spawnMarkerName) select 1), 0], _dir, (a3e_arr_extraction_boat select floor (random count a3e_arr_extraction_boat)), A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
+_result = [[((getMarkerPos _spawnMarkerName) select 0) - 80, ((getMarkerPos _spawnMarkerName) select 1), 0], _dir, a3e_arr_extraction_boat call A3E_fnc_selectRandomWeightedFromSet, A3E_VAR_Side_Blufor] call BIS_fnc_spawnVehicle;
 _boat2 = _result select 0;
 _group2 = _result select 2;
 

--- a/Code/functions/Server/fn_initServer.sqf
+++ b/Code/functions/Server/fn_initServer.sqf
@@ -555,8 +555,8 @@ waitUntil {scriptDone _scriptHandle};
             _createNewGroup = false;
         };
         
-        //(a3e_arr_Escape_StartPositionGuardTypes select floor (random count a3e_arr_Escape_StartPositionGuardTypes)) createUnit [_pos, _guardGroup, "", (0.5), "CAPTAIN"];
-        _guardGroup createUnit [(a3e_arr_Escape_StartPositionGuardTypes select floor (random count a3e_arr_Escape_StartPositionGuardTypes)), _pos, [], 0, "FORM"];
+        //(a3e_arr_Escape_StartPositionGuardTypes call A3E_fnc_selectRandomWeightedFromSet) createUnit [_pos, _guardGroup, "", (0.5), "CAPTAIN"];
+        _guardGroup createUnit [a3e_arr_Escape_StartPositionGuardTypes call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
         
         if (count units _guardGroup >= 2) then {
             _createNewGroup = true;

--- a/Code/functions/Spawning/fn_onEnemySoldierSpawn.sqf
+++ b/Code/functions/Spawning/fn_onEnemySoldierSpawn.sqf
@@ -39,7 +39,7 @@ if(random 100 < 70) then {
 		if(_nighttime) then {
 			_scopes = _scopes + A3E_arr_NightScopes;
 		};
-		_scope = selectRandom _scopes;
+		_scope = _scopes call A3E_fnc_selectRandomWeightedFromSet;
 		_unit addPrimaryWeaponItem _scope;
 	};
 };
@@ -69,7 +69,7 @@ if((random 100 < 15) OR (_nighttime)) then {
 
 //Bipod chance
 if((random 100 < 20)) then {
-	_unit addPrimaryWeaponItem (selectRandom a3e_arr_Bipods);
+	_unit addPrimaryWeaponItem (a3e_arr_Bipods call A3E_fnc_selectRandomWeightedFromSet);
 };
 
 //Chance for silencers

--- a/Code/functions/Spawning/fn_spawnPatrol.sqf
+++ b/Code/functions/Spawning/fn_spawnPatrol.sqf
@@ -21,10 +21,10 @@ private _group = creategroup _side;
 
 ["Creating group"] call a3e_fnc_debugmsg;
 
-_unit = _group createUnit [selectRandom _leaderArray, _pos, [], 0, "FORM"];
+_unit = _group createUnit [_leaderArray call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
 [_unit] call A3E_fnc_onEnemySoldierSpawn;
 for "_x" from 1 to _count do {
-   _unit = _group createUnit [selectRandom _unitArray, _pos, [], 0, "FORM"];
+   _unit = _group createUnit [_unitArray call A3E_fnc_selectRandomWeightedFromSet, _pos, [], 0, "FORM"];
    [_unit] call A3E_fnc_onEnemySoldierSpawn;
 };
 _group

--- a/Code/functions/Templates/fn_AmmoDepot.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot.sqf
@@ -157,7 +157,7 @@
     // Statics
     
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
         _randomNo = random 100;
         _pos = [(_middlePos select 0) + 10, (_middlePos select 1) + 10, 0];
@@ -186,7 +186,7 @@
     // Cars
     
     if (random 10 > 1 && count _parkedVehicleClasses > 0) then {
-        _car = selectRandom _parkedVehicleClasses;
+        _car = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     }
     else {
         _car = "";

--- a/Code/functions/Templates/fn_AmmoDepot2.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot2.sqf
@@ -60,7 +60,7 @@ _obj setPosATL _pos;
     // Cars
     
     if (random 10 > 1 && count _parkedVehicleClasses > 0) then {
-        _car = selectRandom _parkedVehicleClasses;
+        _car = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     }
 else {
     _car = "";
@@ -109,7 +109,7 @@ if (_car != "") then {
  // Statics
 
  if (count _staticWeaponClasses > 0) then {
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 
     _pos = [_center,_center vectorAdd [-11.7528,-6.52271,0.0750003],_rotation] call A3E_fnc_rotatePosition;
     _obj = createVehicle [_gun, _pos, [], 0, "NONE"];

--- a/Code/functions/Templates/fn_AmmoDepot3.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot3.sqf
@@ -38,7 +38,7 @@ _fnc_createObject = {
     // Cars
     
     if (random 10 > 1 && count _parkedVehicleClasses > 0) then {
-        _car = selectRandom _parkedVehicleClasses;
+        _car = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     }
     else {
         _car = "";
@@ -60,7 +60,7 @@ _fnc_createObject = {
 	// Statics
     
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
 		_pos = [_center,_center vectorAdd [6.0531,12.4585,-0.00143909],_rotation] call A3E_fnc_rotatePosition;
 		_obj = createVehicle [_gun, _pos, [], 0, "NONE"];
@@ -70,7 +70,7 @@ _fnc_createObject = {
 		[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
     };
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
 		_pos = [_center,_center vectorAdd [3.42651,-6.48389,-0.00143814],_rotation] call A3E_fnc_rotatePosition;
 		_obj = createVehicle [_gun, _pos, [], 0, "NONE"];

--- a/Code/functions/Templates/fn_AmmoDepot4.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot4.sqf
@@ -38,7 +38,7 @@ private _fnc_createObject = {
     // Cars
     
     if (random 10 > 1 && count _parkedVehicleClasses > 0) then {
-        _car = selectRandom _parkedVehicleClasses;
+        _car = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     }
     else {
         _car = "";
@@ -60,7 +60,7 @@ private _fnc_createObject = {
 	// Statics
     
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
 		_pos = [_center,_center vectorAdd [-14.3452,-5.09326,-0.00143909],_rotation] call A3E_fnc_rotatePosition;
 		_obj = createVehicle [_gun, _pos, [], 0, "NONE"];
@@ -70,7 +70,7 @@ private _fnc_createObject = {
 		[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
     };
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
 		_pos = [_center,_center vectorAdd [15.0289,10.7007,-0.00143814],_rotation] call A3E_fnc_rotatePosition;
 		_obj = createVehicle [_gun, _pos, [], 0, "NONE"];

--- a/Code/functions/Templates/fn_AmmoDepot5.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot5.sqf
@@ -37,7 +37,7 @@ private _fnc_createObject = {
     // Cars
     
     if (random 10 > 1 && count _parkedVehicleClasses > 0) then {
-        _car = selectRandom _parkedVehicleClasses;
+        _car = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     }
     else {
         _car = "";
@@ -59,7 +59,7 @@ private _fnc_createObject = {
 	// Statics
     
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
 		_pos = [_center,_center vectorAdd [-7.66699,-5.83887,-0.00143909],_rotation] call A3E_fnc_rotatePosition;
 		_obj = createVehicle [_gun, _pos, [], 0, "NONE"];
@@ -69,7 +69,7 @@ private _fnc_createObject = {
 		[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
     };
     if (count _staticWeaponClasses > 0) then {
-        _gun = selectRandom _staticWeaponClasses;
+        _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
         
 		_pos = [_center,_center vectorAdd [-13.532,13.2534,-0.00143814],_rotation] call A3E_fnc_rotatePosition;
 		_obj = createVehicle [_gun, _pos, [], 0, "NONE"];

--- a/Code/functions/Templates/fn_BuildComCenter.sqf
+++ b/Code/functions/Templates/fn_BuildComCenter.sqf
@@ -268,14 +268,14 @@ if (count _staticWeaponClasses > 0) then {
     _pos = [-17, 13.5];
     _dir = 0;
     
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
     _static = [_gun, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	[_static,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
     
     _pos = [17, -9.5];
     _dir = 135;
     
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
     _static = [_gun, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	[_static,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
 };
@@ -285,13 +285,13 @@ if (count _parkedVehicleClasses > 0) then {
     _pos = [11.5, 12];
     _dir = 270;
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateVehicle;
     //_object = _vehicle createVehicle [_realPos, [], 0, "CAN_COLLIDE"];
 	
     _pos = [11.5, 6.5];
     _dir = 270;
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 };

--- a/Code/functions/Templates/fn_BuildComCenter2.sqf
+++ b/Code/functions/Templates/fn_BuildComCenter2.sqf
@@ -76,17 +76,17 @@ _obj allowDamage false;
 if (count _staticWeaponClasses > 0) then {
     // Statics
 
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[-2.43372,-2.20557,17.3168],_rotation,181.412] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
 };
 
 if (count _parkedVehicleClasses > 0) then {
     // Cars
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[2.64014,-9.41113,-0.446728],_rotation,269.044] call _fnc_createObject;
     
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[2.50159,-4.73682,-0.446451],_rotation,269.044] call _fnc_createObject;
 };

--- a/Code/functions/Templates/fn_BuildComCenter3.sqf
+++ b/Code/functions/Templates/fn_BuildComCenter3.sqf
@@ -63,21 +63,21 @@ _obj allowDamage false;
 if (count _staticWeaponClasses > 0) then {
     // Statics
 
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[-10.9712,-12.5483,-0.0121183],_rotation,271.186] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner;
 	
-	_gun = selectRandom _staticWeaponClasses;
+	_gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[-11.2578,13.0923,-0.0121183],_rotation,326.452] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner;
 };
 
 if (count _parkedVehicleClasses > 0) then {
     // Cars
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[-4.02551,-7.95752,-0.00933647],_rotation,269.625] call _fnc_createObject;
     
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[6.86597,6.07422,-0.00949287],_rotation,0.0176632] call _fnc_createObject;
 };

--- a/Code/functions/Templates/fn_BuildComCenter4.sqf
+++ b/Code/functions/Templates/fn_BuildComCenter4.sqf
@@ -41,22 +41,22 @@ _obj allowDamage false;
 if (count _staticWeaponClasses > 0) then {
     // Statics
 
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[-3.02271,-15.2334,-0.00143909],_rotation,271.186] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner;
 	
-	_gun = selectRandom _staticWeaponClasses;
+	_gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[17.5204,-21.04,17.8909],_rotation,326.452] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner;
 };
 
 if (count _parkedVehicleClasses > 0) then {
     // Cars
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[-4.1178,-4.31885,4.76837],_rotation,269.625] call _fnc_createObject;
     
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[1.12317,-4.82031,4.76837],_rotation,0.0176632] call _fnc_createObject;
 };
 

--- a/Code/functions/Templates/fn_BuildComCenter5.sqf
+++ b/Code/functions/Templates/fn_BuildComCenter5.sqf
@@ -41,22 +41,22 @@ _obj allowDamage false;
 if (count _staticWeaponClasses > 0) then {
     // Statics
 
-    _gun = selectRandom _staticWeaponClasses;
+    _gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[-2.85498,1.03955,2.78144],_rotation,271.186] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner;
 	
-	_gun = selectRandom _staticWeaponClasses;
+	_gun = _staticWeaponClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_gun,_center,[18.1477,3.35449,-0.00143814],_rotation,326.452] call _fnc_createObject;
 	[_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner;
 };
 
 if (count _parkedVehicleClasses > 0) then {
     // Cars
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[-17.0812,1.57861,4.76837],_rotation,269.625] call _fnc_createObject;
     
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
 	_obj = [_vehicle,_center,[-17.1572,5.45752,4.76837],_rotation,0.0176632] call _fnc_createObject;
 };
 

--- a/Code/functions/Templates/fn_BuildMotorPool.sqf
+++ b/Code/functions/Templates/fn_BuildMotorPool.sqf
@@ -567,13 +567,13 @@ if (count _staticWeaponClasses > 0) then {
     _dir = 173;
     
     _guns = _staticWeaponClasses;
-    _gun = selectRandom _guns;
+    _gun = _guns call A3E_fnc_selectRandomWeightedFromSet;
     _static = [_gun, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	[_static,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
 };
 
 // Armor
-_armor = selectRandom _parkedArmorClasses;
+_armor = _parkedArmorClasses call A3E_fnc_selectRandomWeightedFromSet;
 
 if (count _parkedArmorClasses > 0) then {
 
@@ -599,7 +599,7 @@ if (count _parkedVehicleClasses > 0) then {
     _pos = [11.136, 7.155];
     _dir = 180;
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     _stupidvehicle = [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateVehicle;
 	
 	_stupidvehicle setfuel (random 1);
@@ -611,7 +611,7 @@ if (_random < .3 ) then {
     _pos = [-20.35, -1.202];
     _dir = 100;
     
-    _vehicle = selectRandom _parkedVehicleClasses;
+    _vehicle = _parkedVehicleClasses call A3E_fnc_selectRandomWeightedFromSet;
     _stupidvehicle = [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	
 	_stupidvehicle setfuel (random 1);

--- a/Code/functions/Templates/fn_CrashSite.sqf
+++ b/Code/functions/Templates/fn_CrashSite.sqf
@@ -22,7 +22,7 @@ if (count a3e_arr_CrashSiteWrecksCar >0) then {
 
 //Create a crashed object
 _dir = random 360;
-_object = createVehicle [_TypeOfWreck select(floor(random(count(_TypeOfWreck)))), _position, [], 0, "NONE"];
+_object = createVehicle [_TypeOfWreck call A3E_fnc_selectRandomWeightedFromSet, _position, [], 0, "NONE"];
 _object setPos _position;
 _object setDir _dir;
 
@@ -104,9 +104,9 @@ _boxpos = _position findEmptyPosition [3,15,_boxType];
 
 	
 	_grp = createGroup A3E_VAR_Side_Blufor;
-	_deadcrew = _grp createUnit [_typeOfUnit select(floor(random(count(_typeOfUnit)))), getpos _box, [], 15, "FORM"] ;   
+	_deadcrew = _grp createUnit [_typeOfUnit call A3E_fnc_selectRandomWeightedFromSet, getpos _box, [], 15, "FORM"] ;   
 	_deadcrew setdammage 1;
-	_deadcrew = _grp createUnit [_typeOfUnit select(floor(random(count(_typeOfUnit)))), getpos _box, [], 15, "FORM"] ;   
+	_deadcrew = _grp createUnit [_typeOfUnit call A3E_fnc_selectRandomWeightedFromSet, getpos _box, [], 15, "FORM"] ;   
 	_deadcrew setdammage 1;
 	
 	diag_log format["fn_CrashSite: Camp created at %1", getpos _box];

--- a/Code/functions/Templates/fn_MortarSite.sqf
+++ b/Code/functions/Templates/fn_MortarSite.sqf
@@ -35,7 +35,7 @@ _dir = 0;
 _obj setdir _dir;
 _obj setpos _objpos;
 _objpos = _position vectoradd [-0.105957,-0.183716,0.0648341];
-_obj = createVehicle [a3e_arr_MortarSite select(floor(random(count(a3e_arr_MortarSite)))), _objpos, [], 0, "NONE"];
+_obj = createVehicle [a3e_arr_MortarSite call A3E_fnc_selectRandomWeightedFromSet, _objpos, [], 0, "NONE"];
 _gunner = [_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
 a3e_var_artillery_units pushBack _obj;
 _dir = 180.555;

--- a/Code/functions/Templates/fn_MortarSite2.sqf
+++ b/Code/functions/Templates/fn_MortarSite2.sqf
@@ -35,7 +35,7 @@ _dir = 0;
 _obj setdir _dir;
 _obj setpos _objpos;
 _objpos = _position vectoradd [-0.105957,-0.183716,0.0648341];
-_obj = createVehicle [a3e_arr_MortarSite select(floor(random(count(a3e_arr_MortarSite)))), _objpos, [], 0, "NONE"];
+_obj = createVehicle [a3e_arr_MortarSite call A3E_fnc_selectRandomWeightedFromSet, _objpos, [], 0, "NONE"];
 _gunner = [_obj,A3E_VAR_Side_Opfor] spawn A3E_fnc_AddStaticGunner; 
 a3e_var_artillery_units pushBack _obj;
 _dir = 180.555;

--- a/Code/include/functions.hpp
+++ b/Code/include/functions.hpp
@@ -32,13 +32,14 @@ class CfgFunctions
 		};
 		class InitLocalPlayer {
 			postInit = 0;
-		};			
+		};
 		class cleanupTerrain {};
 		class handleRating {};
 		class handleScore {};
 		class CheckCampDistance {};
 		class FireSmokeFX {};
 		class OnVehicleSpawn {};
+		class selectRandomWeightedFromSet {};
 
 		};
 		class AI
@@ -78,7 +79,7 @@ class CfgFunctions
             };
 			class initPlayer {};
 			class watchKnownPosition {};
-			class parameterInit {}; 
+			class parameterInit {};
             class createComCenters {};
             class createMotorPool {};
             class createAmmoDepots {};
@@ -123,14 +124,14 @@ class CfgFunctions
 			class AmmoDepot2 {};
 			class AmmoDepot3 {};
 			class AmmoDepot4 {};
-			class AmmoDepot5 {};			
+			class AmmoDepot5 {};
 			class CrashSite {};
 			class MortarSite {};
 			class MortarSite2 {};
 			class Roadblock {};
 			class Roadblock2 {};
 			class Roadblock3 {};
-			class Roadblock4 {};			
+			class Roadblock4 {};
 		};
 		class Chronos
 		{
@@ -151,8 +152,8 @@ class CfgFunctions
 	{
 		class DRN
 		{
-			class AmbientInfantry {}; 
-			class MoveInfantryGroup {}; 
+			class AmbientInfantry {};
+			class MoveInfantryGroup {};
 			class MonitorEmptyGroups {};
 			class PopulateLocation {};
 			class DepopulateLocation {};
@@ -161,7 +162,7 @@ class CfgFunctions
 			class InsertionTruck {};
 			class MilitaryTraffic {};
 			class MoveVehicle {};
-			class MotorizedSearchGroup {};	
+			class MotorizedSearchGroup {};
 			class SearchChopper {};
 			class SearchGroup {};
 			class InitVillageMarkers{};

--- a/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
@@ -1,7 +1,7 @@
 /*
  * Description: This file contains the vehicle types and unit types for the units spawned in the mission, and the weapons and magazines found in ammo boxes/cars.
- * "Random array" (used below) means that array will be used to spawn units, and that chance is 1/n that each element will be spawned on each spawn. The array can contain 
- * many elements of the same type, so the example array ["Offroad_DSHKM_INS", "Pickup_PK_INS", "Pickup_PK_INS"] will spawn an Offroad with 1/3 probability, and a 
+ * "Random array" (used below) means that array will be used to spawn units, and that chance is 1/n that each element will be spawned on each spawn. The array can contain
+ * many elements of the same type, so the example array ["Offroad_DSHKM_INS", "Pickup_PK_INS", "Pickup_PK_INS"] will spawn an Offroad with 1/3 probability, and a
  * Pickup with 2/3 probability.
  */
 
@@ -96,234 +96,92 @@ a3e_arr_PrisonBackpackWeapons pushback ["CUP_hgun_MicroUzi_snds","CUP_30Rnd_9x19
 
 
 
-// Random array. Civilian vehicle classes for ambient traffic.
-a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = [
-	"CUP_C_Datsun"
-	,"CUP_C_Datsun"
-	,"CUP_C_Datsun"
-	,"CUP_C_Datsun"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_camo_Civ"
-	,"CUP_C_Golf4_camodark_Civ"
-	,"CUP_C_Golf4_camodigital_Civ"
-	,"CUP_C_Golf4_crowe_Civ"
-	,"CUP_C_Golf4_kitty_Civ"
-	,"CUP_C_Golf4_reptile_Civ"
-	,"CUP_C_Golf4_whiteblood_Civ"
+// Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
+a3e_arr_Escape_EnemyCivilianCarTypes = [
+	[
+		"CUP_C_Datsun"
+		,"CUP_C_Datsun_4seat"
+		,"CUP_C_Datsun_Covered"
+		,"CUP_C_Datsun_Plain"
+		,"CUP_C_Datsun_Tubeframe"
+	]
+	,[
+		["CUP_C_Golf4_random_Civ", 5]
+		,"CUP_C_Golf4_camo_Civ"
+		,"CUP_C_Golf4_camodark_Civ"
+		,"CUP_C_Golf4_camodigital_Civ"
+		,"CUP_C_Golf4_crowe_Civ"
+		,"CUP_C_Golf4_kitty_Civ"
+		,"CUP_C_Golf4_reptile_Civ"
+		,"CUP_C_Golf4_whiteblood_Civ"
+	]
 	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_TT650_CIV"
-	,"CUP_C_TT650_CIV"
-	,"CUP_C_TT650_CIV"
-	,"CUP_C_TT650_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Tubeframe"
-	,"CUP_C_Datsun_Tubeframe"
-	,"CUP_C_Datsun_Tubeframe"
+	,[
+		"CUP_C_Skoda_Blue_CIV"
+		,"CUP_C_Skoda_Green_CIV"
+		,"CUP_C_Skoda_Red_CIV"
+		,"CUP_C_Skoda_White_CIV"
+	]
 	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_LADA_LM_CIV"
-	,"CUP_LADA_LM_CIV"
-	,"CUP_LADA_LM_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_CIV"
-	,"CUP_C_Tractor_Old_CIV"
-	,"CUP_C_Tractor_Old_CIV"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Open_Civ_03"
-	,"CUP_C_Ural_Open_Civ_03"
-	,"CUP_C_Ural_Open_Civ_03"
-    ,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_TT650_TK_CIV"
-	,"CUP_C_TT650_TK_CIV"
-	,"CUP_C_TT650_TK_CIV"
-	,"CUP_C_TT650_TK_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
+	,[
+		"CUP_C_Lada_GreenTK_CIV"
+		,"CUP_C_Lada_Red_CIV"
+		,"CUP_C_Lada_White_CIV"
+		,"CUP_LADA_LM_CIV"
+	]
 	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"];
+	,[
+		"CUP_C_S1203_CIV"
+		,"CUP_C_S1203_Militia_CIV"
+	]
+	,[
+		"CUP_C_SUV_CIV"
+		,"CUP_C_SUV_TK"
+	]
+	,[
+		"CUP_C_UAZ_Open_TK_CIV"
+		,"CUP_C_UAZ_Unarmed_TK_CIV"
+	]
+	,[
+		"CUP_C_Ural_Civ_01"
+		,"CUP_C_Ural_Civ_02"
+		,"CUP_C_Ural_Civ_03"
+		,"CUP_C_Ural_Open_Civ_01"
+		,"CUP_C_Ural_Open_Civ_02"
+		,"CUP_C_Ural_Open_Civ_03"
+	]
+	,[
+		"CUP_C_V3S_Covered_TKC"
+		,"CUP_C_V3S_Open_TKC"
+	]
+	,[
+		"CUP_C_Volha_Blue_TKCIV"
+		,"CUP_C_Volha_Gray_TKCIV"
+		,"CUP_C_Volha_Limo_TKCIV"
+	]];
 	if(Param_UseDLCApex==1) then {
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Offroad_02_unarmed_F";
+		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
 	};
 	if(Param_UseDLCLaws==1) then {
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_medevac_F";
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_vehicle_F";
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_service_F";
-	a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses pushback "C_Van_02_transport_F";
+		a3e_arr_Escape_EnemyCivilianCarTypes append [
+			[
+				"C_Van_02_medevac_F"
+				,"C_Van_02_vehicle_F"
+				,"C_Van_02_service_F"
+				,"C_Van_02_transport_F"
+			]]
 	};
+
+// Random array. Civilian vehicle classes for ambient traffic.
+a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses = a3e_arr_Escape_EnemyCivilianCarTypes + [
+	[
+		"CUP_C_Tractor_CIV"
+		,"CUP_C_Tractor_Old_CIV"
+	]
+	,[
+		"CUP_C_TT650_CIV"
+		,"CUP_C_TT650_TK_CIV"
+	]];
 
 // Random arrays. Enemy vehicle classes for ambient traffic.
 // Variable _enemyFrequency applies to server parameter, and can be one of the values 1 (Few), 2 (Some) or 3 (A lot).
@@ -400,7 +258,7 @@ switch (_enemyFrequency) do {
 		,"CUP_B_M1A1_Woodland_USMC"
 		,"CUP_B_M1A2_TUSK_MG_USMC"];
         a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses_IND = [
-		//Unarmed Cars  1 set 
+		//Unarmed Cars  1 set
 		"CUP_I_LR_Ambulance_RACS"
 		,"CUP_I_LR_Ambulance_RACS"
 		,"CUP_I_LR_Ambulance_RACS"
@@ -516,7 +374,7 @@ switch (_enemyFrequency) do {
 		,"CUP_B_LAV25_HQ_USMC"
 		,"CUP_B_LAV25_HQ_USMC"
 		,"CUP_B_LAV25_HQ_USMC"
-		//Heavily Armed APCs or AA  1 set  
+		//Heavily Armed APCs or AA  1 set
 		,"CUP_B_AAV_USMC"
 		,"CUP_B_LAV25_USMC"
 		,"CUP_B_LAV25M240_USMC"
@@ -561,10 +419,10 @@ switch (_enemyFrequency) do {
 		,"CUP_I_M113_RACS_URB"
 		,"CUP_I_LAV25_HQ_RACS"  //2
 		,"CUP_I_M113_RACS"
-		,"CUP_I_M113_RACS_URB"  
+		,"CUP_I_M113_RACS_URB"
 		,"CUP_I_LAV25_HQ_RACS"  //3
 		,"CUP_I_M113_RACS"
-		,"CUP_I_M113_RACS_URB"  
+		,"CUP_I_M113_RACS_URB"
 		,"CUP_I_LAV25_HQ_RACS"  //4
 		,"CUP_I_M113_RACS"
 		,"CUP_I_M113_RACS_URB"
@@ -647,7 +505,7 @@ switch (_enemyFrequency) do {
 		,"CUP_B_LAV25_HQ_USMC"
 		,"CUP_B_LAV25_HQ_USMC"
 		,"CUP_B_LAV25_HQ_USMC"
-		//Heavily Armed APCs or AA  2 sets 
+		//Heavily Armed APCs or AA  2 sets
 		,"CUP_B_AAV_USMC"  //1
 		,"CUP_B_LAV25_USMC"
 		,"CUP_B_LAV25M240_USMC"
@@ -725,71 +583,42 @@ switch (_enemyFrequency) do {
 
 // Random array. General infantry types. E.g. village patrols, ambient infantry, ammo depot guards, communication center guards, etc.
 a3e_arr_Escape_InfantryTypes = [
-	"CUP_B_USMC_Soldier"
-	,"CUP_B_USMC_Soldier"
-	,"CUP_B_USMC_Soldier"
-	,"CUP_B_USMC_Soldier"
-	,"CUP_B_USMC_Soldier_GL"
-	,"CUP_B_USMC_Soldier_GL"
+	["CUP_B_USMC_Soldier", 4]
+	,["CUP_B_USMC_Soldier_GL", 2]
 	,"CUP_B_USMC_Officer"
-	,"CUP_B_USMC_Soldier_SL"
-	,"CUP_B_USMC_Soldier_SL"
-	,"CUP_B_USMC_Soldier_TL"
-	,"CUP_B_USMC_Soldier_TL"
-	,"CUP_B_USMC_Soldier_LAT"
-	,"CUP_B_USMC_Soldier_LAT"
+	,["CUP_B_USMC_Soldier_SL", 2]
+	,["CUP_B_USMC_Soldier_TL", 2]
+	,["CUP_B_USMC_Soldier_LAT", 2]
 	,"CUP_B_USMC_Soldier_HAT"
-	,"CUP_B_USMC_Soldier_AA"
-	,"CUP_B_USMC_Soldier_AA"
-	,"CUP_B_USMC_Medic"
-	,"CUP_B_USMC_Medic"
-	,"CUP_B_USMC_Soldier_AR"
-	,"CUP_B_USMC_Soldier_AR"
-	,"CUP_B_USMC_Soldier_AR"
+	,["CUP_B_USMC_Soldier_AA", 2]
+	,["CUP_B_USMC_Medic", 2]
+	,["CUP_B_USMC_Soldier_AR", 3]
 	,"CUP_B_USMC_Spotter"
 	,"CUP_B_USMC_Sniper_M40A3"
 	,"CUP_B_USMC_Sniper_M107"
 	,"CUP_B_USMC_Soldier_Marksman"
-	,"CUP_B_USMC_Engineer"
-	,"CUP_B_USMC_Engineer"
+	,["CUP_B_USMC_Engineer", 2]
 	,"CUP_B_USMC_Soldier_AT"
-	,"CUP_B_USMC_Soldier_MG"
-	,"CUP_B_USMC_Soldier_MG"
+	,["CUP_B_USMC_Soldier_MG", 2]
 	,"CUP_B_USMC_Soldier_UAV"
 	,"CUP_B_USMC_SpecOps"
 	,"CUP_B_USMC_SpecOps_SD"];
 a3e_arr_Escape_InfantryTypes_Ind = [
-	"CUP_I_RACS_Soldier_AA_wdl"
-	,"CUP_I_RACS_Soldier_AA_wdl"
+	["CUP_I_RACS_Soldier_AA_wdl", 2]
 	,"CUP_I_RACS_Soldier_AAT_wdl"
-	,"CUP_I_RACS_Soldier_AMG_wdl"
-	,"CUP_I_RACS_Soldier_AMG_wdl"
-	,"CUP_I_RACS_Soldier_MAT_wdl"
-	,"CUP_I_RACS_Soldier_MAT_wdl"
-	,"CUP_I_RACS_AR_wdl"
-	,"CUP_I_RACS_AR_wdl"
-	,"CUP_I_RACS_Engineer_wdl"
-	,"CUP_I_RACS_Engineer_wdl"
-	,"CUP_I_RACS_GL_wdl"
-	,"CUP_I_RACS_GL_wdl"
+	,["CUP_I_RACS_Soldier_AMG_wdl", 2]
+	,["CUP_I_RACS_Soldier_MAT_wdl", 2]
+	,["CUP_I_RACS_AR_wdl", 2]
+	,["CUP_I_RACS_Engineer_wdl", 2]
+	,["CUP_I_RACS_GL_wdl", 2]
 	,"CUP_I_RACS_Soldier_HAT_wdl"
-	,"CUP_I_RACS_MMG_wdl"
-	,"CUP_I_RACS_MMG_wdl"
+	,["CUP_I_RACS_MMG_wdl", 2]
 	,"CUP_I_RACS_M_wdl"
-	,"CUP_I_RACS_Medic_wdl"
-	,"CUP_I_RACS_Medic_wdl"
-	,"CUP_I_RACS_Officer_wdl"
-	,"CUP_I_RACS_Officer_wdl"
-	,"CUP_I_RACS_Soldier_wdl"
-	,"CUP_I_RACS_Soldier_wdl"
-	,"CUP_I_RACS_Soldier_wdl"
-	,"CUP_I_RACS_Soldier_wdl"
-	,"CUP_I_RACS_Soldier_Light_wdl"
-	,"CUP_I_RACS_Soldier_Light_wdl"
-	,"CUP_I_RACS_Soldier_Light_wdl"
-	,"CUP_I_RACS_Soldier_Light_wdl"
-	,"CUP_I_RACS_Soldier_LAT_wdl"
-	,"CUP_I_RACS_Soldier_LAT_wdl"
+	,["CUP_I_RACS_Medic_wdl", 2]
+	,["CUP_I_RACS_Officer_wdl", 2]
+	,["CUP_I_RACS_Soldier_wdl", 4]
+	,["CUP_I_RACS_Soldier_Light_wdl", 4]
+	,["CUP_I_RACS_Soldier_LAT_wdl", 2]
 	,"CUP_I_RACS_Sniper_wdl"
 	,"CUP_I_RACS_SL_wdl"];
 a3e_arr_recon_InfantryTypes = [
@@ -812,14 +641,16 @@ a3e_arr_recon_I_InfantryTypes = [
 
 // Random array. A roadblock has a manned vehicle. This array contains possible manned vehicles (can be of any kind, like cars, armored and statics).
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes = [
-    "CUP_B_HMMWV_Avenger_USMC"
-	,"CUP_B_M1151_Deploy_USMC"   
-	,"CUP_B_M1151_Mk19_USMC"
-	,"CUP_B_M1165_GMV_USMC"
-	,"CUP_B_M1167_USMC"
-	,"CUP_B_RG31_Mk19_OD_USMC"
-	,"CUP_B_RG31_M2_OD_USMC"
-	,"CUP_B_RG31_M2_OD_GC_USMC"];
+    [
+		"CUP_B_HMMWV_Avenger_USMC"
+		,"CUP_B_M1151_Deploy_USMC"
+		,"CUP_B_M1151_Mk19_USMC"
+		,"CUP_B_M1165_GMV_USMC"
+		,"CUP_B_M1167_USMC"]
+	,[
+		"CUP_B_RG31_Mk19_OD_USMC"
+		,"CUP_B_RG31_M2_OD_USMC"
+		,"CUP_B_RG31_M2_OD_GC_USMC"]];
 a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind = [
 	"CUP_I_LR_MG_RACS"
 	,"CUP_I_LR_MG_RACS"
@@ -844,7 +675,7 @@ a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses = [
 
 
 
-// A communication center is guarded by vehicles depending on variable _enemyFrequency. 1 = a random light armor. 2 = a random heavy armor. 3 = a random 
+// A communication center is guarded by vehicles depending on variable _enemyFrequency. 1 = a random light armor. 2 = a random heavy armor. 3 = a random
 // light *and* a random heavy armor.
 
 // Random array. Light armored vehicles guarding the communication centers.
@@ -890,223 +721,6 @@ a3e_arr_ComCenParkedVehicles = [
 	,"CUP_B_RG31_M2_OD_GC_USMC"
 	,"CUP_B_HMMWV_Avenger_USMC"
 	,"CUP_B_AAV_USMC"];
-
-// Random array. Enemies sometimes use civilian vehicles in their unconventional search for players. The following car types may be used.
-a3e_arr_Escape_EnemyCivilianCarTypes = [
-	"CUP_C_Datsun"
-	,"CUP_C_Datsun"
-	,"CUP_C_Datsun"
-	,"CUP_C_Datsun"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Datsun_4seat"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_random_Civ"
-	,"CUP_C_Golf4_camo_Civ"
-	,"CUP_C_Golf4_camodark_Civ"
-	,"CUP_C_Golf4_camodigital_Civ"
-	,"CUP_C_Golf4_crowe_Civ"
-	,"CUP_C_Golf4_kitty_Civ"
-	,"CUP_C_Golf4_reptile_Civ"
-	,"CUP_C_Golf4_whiteblood_Civ"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Octavia_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_Skoda_Blue_CIV"
-	,"CUP_C_Skoda_Green_CIV"
-	,"CUP_C_Skoda_Red_CIV"
-	,"CUP_C_Skoda_White_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_S1203_Militia_CIV"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Covered"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Plain"
-	,"CUP_C_Datsun_Tubeframe"
-	,"CUP_C_Datsun_Tubeframe"
-	,"CUP_C_Datsun_Tubeframe"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Ikarus_Chernarus"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_C_Lada_White_CIV"
-	,"CUP_LADA_LM_CIV"
-	,"CUP_LADA_LM_CIV"
-	,"CUP_LADA_LM_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_Lada_Red_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_SUV_CIV"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Civ_03"
-	,"CUP_C_Ural_Open_Civ_03"
-	,"CUP_C_Ural_Open_Civ_03"
-	,"CUP_C_Ural_Open_Civ_03"
-    ,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Open_Civ_01"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Civ_02"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_Ural_Open_Civ_02"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_S1203_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_Lada_GreenTK_CIV"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_LR_Transport_CTK"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Open_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_V3S_Covered_TKC"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_SUV_TK"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Unarmed_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_UAZ_Open_TK_CIV"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Ural_Civ_01"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Blue_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Gray_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"
-	,"CUP_C_Volha_Limo_TKCIV"];
-	if(Param_UseDLCApex==1) then {
-		a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Offroad_02_unarmed_F";
-	};
-	if(Param_UseDLCLaws==1) then {
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_medevac_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_vehicle_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_service_F";
-	a3e_arr_Escape_EnemyCivilianCarTypes pushback "C_Van_02_transport_F";
-	};
 
 
 // Vehicles, weapons and ammo at ammo depots

--- a/Mods/CUP RU/UnitClasses.sqf
+++ b/Mods/CUP RU/UnitClasses.sqf
@@ -369,16 +369,21 @@ a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses = [
 
 //Random array. Types of helicopters to spawn
 a3e_arr_O_attack_heli = [
-	"CUP_O_Ka50_AA_RU"
-	,"CUP_O_Ka50_RU"
-	,"CUP_O_Ka52_RU"
-	,"CUP_O_Ka52_Blk_RU"
-	,"CUP_O_Mi24_P_RU"
-	,"CUP_O_Mi24_V_RU"
-	,"CUP_O_Ka52_RU"
-	,"CUP_O_Ka52_Blk_RU"
-	,"CUP_O_Ka52_GreyCamo_RU"
-	,"CUP_O_Ka52_Grey_RU"];
+	[
+		"CUP_O_Ka50_AA_RU",
+		"CUP_O_Ka50_RU"
+	]
+	,[
+		"CUP_O_Ka52_Blk_RU"
+		,"CUP_O_Ka52_Grey_RU"
+		,"CUP_O_Ka52_GreyCamo_RU"
+		,"CUP_O_Ka52_RU"
+	]
+	,[
+		"CUP_O_Mi24_P_RU"
+		,"CUP_O_Mi24_V_RU"
+	]
+];
 a3e_arr_O_transport_heli = [
 	"CUP_O_MI6A_RU"
 	,"CUP_O_MI6T_RU"


### PR DESCRIPTION
When merged this pull request will:
- add `selectRandomWeightedFromSet` function;
- use this function in all proper places instead of `selectRandom`;
- rewrite parts of some CUP configs to show how to use the function;
- optimize civilian vehicle arrays in CUP USMC-RACS config (they differ only with TT650 and Tractor).

Purposes of this function:
- use array of values in configs instead of group of values. This allows to use classes more specifically. E.g. 
```
	[
		"CUP_O_Ka50_AA_RU",
		"CUP_O_Ka50_RU"
	]
	,[
		"CUP_O_Ka52_Blk_RU"
		,"CUP_O_Ka52_Grey_RU"
		,"CUP_O_Ka52_GreyCamo_RU"
		,"CUP_O_Ka52_RU"
	]
	,[
		"CUP_O_Mi24_P_RU"
		,"CUP_O_Mi24_V_RU"
	]
```
array gives 1/3 probability for each Ka50, Ka52 and Mi24 groups (instead 1/6 for Mi24 in original array). Because classes are used better the mission becomes even more replayable;
- use weighted array to set value probability without copy-pasting several times:
```
[
	["CUP_I_RACS_Soldier_AA_wdl", 2]
	,"CUP_I_RACS_Soldier_AAT_wdl"
	,["CUP_I_RACS_Soldier_AMG_wdl", 2]
	,["CUP_I_RACS_Soldier_MAT_wdl", 2]
	,["CUP_I_RACS_AR_wdl", 2]
	,["CUP_I_RACS_Engineer_wdl", 2]
	,["CUP_I_RACS_GL_wdl", 2]
	,"CUP_I_RACS_Soldier_HAT_wdl"
	,["CUP_I_RACS_MMG_wdl", 2]
	,"CUP_I_RACS_M_wdl"
	,["CUP_I_RACS_Medic_wdl", 2]
	,["CUP_I_RACS_Officer_wdl", 2]
	,["CUP_I_RACS_Soldier_wdl", 4]
	,["CUP_I_RACS_Soldier_Light_wdl", 4]
	,["CUP_I_RACS_Soldier_LAT_wdl", 2]
	,"CUP_I_RACS_Sniper_wdl"
	,"CUP_I_RACS_SL_wdl"];
```
Function is recursive so we can use nested arrays and/or weights.

Function is naturally slower than `selectRandom` but it's not critical and it gives much more advantages.

Function name is subject to discuss.