### PR TITLE
Add search chopper FFV units

### DIFF
--- a/Code/Scripts/Escape/CreateSearchChopper.sqf
+++ b/Code/Scripts/Escape/CreateSearchChopper.sqf
@@ -17,7 +17,7 @@
 if (!isServer) exitWith {};
 
 private ["_homePos", "_side", "_searchAreaMarker", "_searchTimeMin", "_refuelTimeMin", "_minSkill", "_maxSkill", "_unitArray", "_debug"];
-private ["_chopper", "_chopperspawn", "_group", "_pilot", "_copilot", "_gunner1", "_gunner2", "_gunner3"];
+private ["_chopper", "_chopperspawn"];
 private ["_vehicleVarName", "_vehicleVarNameBase", "_vehicleVarNameNo"];
 
 _homePos = _this select 0;
@@ -53,10 +53,21 @@ _homePos = _homePos vectorAdd [0,0,100];
 //_chopperspawn = [_homePos, random 360, _type, A3E_VAR_Side_Opfor] call BIS_fnc_spawnVehicle;
 _chopper = createVehicle [_type, _homePos, [], random 360, "FLY"];
 [_chopper] call a3e_fnc_onVehicleSpawn;
-createVehicleCrew _chopper;
+private _group = createVehicleCrew _chopper;
+
 {
 	_x call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 } foreach crew _chopper;
+
+// populate FFV turrets
+private _classList = [a3e_arr_Escape_InfantryTypes_Ind, a3e_arr_Escape_InfantryTypes] select (side _group == A3E_VAR_Side_Opfor);
+{
+	if !(_chopper lockedTurret _x) then {
+		private _soldier = _group createUnit [selectRandom _classList, [0,0,0], [], 0, "NONE"];
+		_soldier moveInTurret [_chopper, _x];
+	};
+} forEach (allTurrets [_chopper, true] - allTurrets [_chopper, false]);
+
 _chopper lock 0;
 _chopper setVehicleVarName _vehicleVarName;
 _chopper call compile format ["%1=_this;", _vehicleVarName];

--- a/Code/Scripts/Escape/CreateSearchChopper.sqf
+++ b/Code/Scripts/Escape/CreateSearchChopper.sqf
@@ -66,7 +66,7 @@ private _classList = [a3e_arr_Escape_InfantryTypes_Ind, a3e_arr_Escape_InfantryT
 		private _soldier = _group createUnit [selectRandom _classList, [0,0,0], [], 0, "NONE"];
 		_soldier moveInTurret [_chopper, _x];
 	};
-} forEach (allTurrets [_chopper, true] - allTurrets [_chopper, false]);
+} forEach (fullCrew [_chopper, "turret", true] select {_x#4} apply {_x#3});
 
 _chopper lock 0;
 _chopper setVehicleVarName _vehicleVarName;


### PR DESCRIPTION
Easy Little-Bird-like choppers become more dangerous.

I skipped `OnSpawnGeneralSoldierUnit` event for FFV units. 0.2-0.6 ammo is quite a little for soldiers in heli and due to arma bug soldiers don't rearm even there are their magazines in heli cargo.

Also I didn't add "eject on dead" code. It's quite fun, dead soldiers fall to ground like shot ducks from flying heli. But I didn't take a decision if it's good or bad. BTW "dead" can be for chopper: then soldiers could lie near crashed heli.