### PR TITLE
Add Virtual Arsenal to additional weapon boxes

### DIFF
--- a/Code/functions/Common/fn_initArsenal.sqf
+++ b/Code/functions/Common/fn_initArsenal.sqf
@@ -1,0 +1,27 @@
+params ["_box"];
+
+if (isNil "a3e_additional_weapon_box_arsenal_cfgPatches") exitWith {};
+
+private _cfgPatchesLower = a3e_additional_weapon_box_arsenal_cfgPatches apply {toLower _x};
+private _cfgWeapons = configFile >> "CfgWeapons";
+private _magazineClasses = [];
+
+private _weaponClasses = '
+    getNumber (_x >> "scope") == 2
+    && {-1 < configSourceAddonList _x findIf {toLower _x in _cfgPatchesLower}}
+    && {_magazineClasses append (getArray (_x >> "magazines") apply {toLower _x}); true}
+' configClasses _cfgWeapons apply {configName _x};
+
+if (!isNil "a3e_additional_weapon_box_arsenal_weapons") then {
+    _weaponClasses append a3e_additional_weapon_box_arsenal_weapons;
+    {
+        _magazineClasses append (getArray (_cfgWeapons >> _x >> "magazines") apply {toLower _x});
+    } forEach a3e_additional_weapon_box_arsenal_weapons;
+};
+
+private _cfgMagazines = configFile >> "CfgMagazines";
+_magazineClasses = _magazineClasses arrayIntersect _magazineClasses apply {configName (_cfgMagazines >> _x)};
+
+["AmmoboxInit", _box] call BIS_fnc_arsenal;
+[_box, _weaponClasses, true, false] call BIS_fnc_addVirtualWeaponCargo;
+[_box, _magazineClasses, true, false] call BIS_fnc_addVirtualMagazineCargo;

--- a/Code/functions/Templates/fn_AmmoDepot.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot.sqf
@@ -308,7 +308,9 @@
 
 	if((Param_Waffelbox)==1) then {
 		_box = createVehicle [a3e_additional_weapon_box_1, [(_middlePos select 0) + 0, (_middlePos select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 		_box = createVehicle [a3e_additional_weapon_box_2, [(_middlePos select 0) + 3, (_middlePos select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 	 };
     // Ordnance
     

--- a/Code/functions/Templates/fn_AmmoDepot2.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot2.sqf
@@ -275,7 +275,9 @@ private ["_weapons", "_weaponMagazines", "_box", "_weaponCount"];
 
 if((Param_Waffelbox)==1) then {
   _box = createVehicle [a3e_additional_weapon_box_1, [(_center select 0) + 0, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+  _box call A3E_fnc_initArsenal;
   _box = createVehicle [a3e_additional_weapon_box_2, [(_center select 0) + 3, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+  _box call A3E_fnc_initArsenal;
 };
     // Ordnance
     

--- a/Code/functions/Templates/fn_AmmoDepot3.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot3.sqf
@@ -197,7 +197,9 @@ _obj = ["Flag_CSAT_F",_center,[7.68066,-4.16943,0],_rotation,266.77] call _fnc_c
 
 	if((Param_Waffelbox)==1) then {
 		_box = createVehicle [a3e_additional_weapon_box_1, [(_center select 0) + 0, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 		_box = createVehicle [a3e_additional_weapon_box_2, [(_center select 0) + 3, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 	 };
     // Ordnance
     

--- a/Code/functions/Templates/fn_AmmoDepot4.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot4.sqf
@@ -196,7 +196,9 @@ _obj = ["Flag_CSAT_F",_center,[-15.5826,-14.6431,0],_rotation,266.77] call _fnc_
 
 	if((Param_Waffelbox)==1) then {
 		_box = createVehicle [a3e_additional_weapon_box_1, [(_center select 0) + 0, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 		_box = createVehicle [a3e_additional_weapon_box_2, [(_center select 0) + 3, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 	 };
     // Ordnance
     

--- a/Code/functions/Templates/fn_AmmoDepot5.sqf
+++ b/Code/functions/Templates/fn_AmmoDepot5.sqf
@@ -194,7 +194,9 @@ _obj = ["Flag_CSAT_F",_center,[-16.4143,-1.93066,0],_rotation,266.77] call _fnc_
 
 	if((Param_Waffelbox)==1) then {
 		_box = createVehicle [a3e_additional_weapon_box_1, [(_center select 0) + 0, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 		_box = createVehicle [a3e_additional_weapon_box_2, [(_center select 0) + 3, (_center select 1) + 3, 0], [], 0, "CAN_COLLIDE"];
+        _box call A3E_fnc_initArsenal;
 	 };
     // Ordnance
     

--- a/Code/include/functions.hpp
+++ b/Code/include/functions.hpp
@@ -39,6 +39,7 @@ class CfgFunctions
 		class CheckCampDistance {};
 		class FireSmokeFX {};
 		class OnVehicleSpawn {};
+		class initArsenal {};
 
 		};
 		class AI

--- a/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP RU vs USMC-RACS/UnitClasses.sqf
@@ -1481,6 +1481,39 @@ a3e_arr_AquaticPatrols = [
 //////////////////////////////////////////////////////////////////
 a3e_additional_weapon_box_1 = "CUP_USBasicWeaponsBox";
 a3e_additional_weapon_box_2 = "CUP_USSpecialWeaponsBox";
+a3e_additional_weapon_box_arsenal_cfgPatches = [
+	"CUP_Weapons_AA12",
+	"CUP_Weapons_ACR",
+	"CUP_Weapons_AS50",
+	"CUP_Weapons_AWM",
+	"CUP_Weapons_CZ750",
+	"CUP_Weapons_CZ805",
+	"CUP_Weapons_EVO",
+	"CUP_Weapons_G36",
+	"CUP_Weapons_HK416",
+	"CUP_Weapons_L129",
+	"CUP_Weapons_L85",
+	"CUP_Weapons_M1014",
+	"CUP_Weapons_M107",
+	"CUP_Weapons_M110",
+	"CUP_Weapons_M14",
+	"CUP_Weapons_M14_DMR",
+	"CUP_Weapons_M16",
+	"CUP_Weapons_M24",
+	"CUP_Weapons_M240",
+	"CUP_Weapons_M249",
+	"CUP_Weapons_M60E4",
+	"CUP_Weapons_Mk48",
+	"CUP_Weapons_RSASS",
+	"CUP_Weapons_Sa58",
+	"CUP_Weapons_SCAR",
+	"CUP_Weapons_Steyr",
+	"CUP_Weapons_West_Attachments",
+	"CUP_Weapons_XM8"];
+a3e_additional_weapon_box_arsenal_weapons = [
+	"CUP_glaunch_M32",
+	"CUP_glaunch_M79",
+	"CUP_glaunch_Mk13"];
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite

--- a/Mods/CUP RU/UnitClasses.sqf
+++ b/Mods/CUP RU/UnitClasses.sqf
@@ -718,6 +718,17 @@ a3e_arr_AquaticPatrols = [
 //////////////////////////////////////////////////////////////////
 a3e_additional_weapon_box_1 = "CUP_RUBasicWeaponsBox";
 a3e_additional_weapon_box_2 = "CUP_RUSpecialWeaponsBox";
+a3e_additional_weapon_box_arsenal_cfgPatches = [
+	"CUP_Weapons_AK",
+	"CUP_Weapons_Bizon",
+	"CUP_Weapons_East_Attachments",
+	"CUP_Weapons_GROZA",
+	"CUP_Weapons_KSVK",
+	"CUP_Weapons_PK",
+	"CUP_Weapons_SVD",
+	"CUP_Weapons_VSS"];
+a3e_additional_weapon_box_arsenal_weapons = [
+	"CUP_glaunch_6G30"];
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite

--- a/Mods/CUP-BAF d/UnitClasses.sqf
+++ b/Mods/CUP-BAF d/UnitClasses.sqf
@@ -869,6 +869,39 @@ a3e_arr_AquaticPatrols = [
 //////////////////////////////////////////////////////////////////
 a3e_additional_weapon_box_1 = "CUP_USBasicWeaponsBox";
 a3e_additional_weapon_box_2 = "CUP_USSpecialWeaponsBox";
+a3e_additional_weapon_box_arsenal_cfgPatches = [
+	"CUP_Weapons_AA12",
+	"CUP_Weapons_ACR",
+	"CUP_Weapons_AS50",
+	"CUP_Weapons_AWM",
+	"CUP_Weapons_CZ750",
+	"CUP_Weapons_CZ805",
+	"CUP_Weapons_EVO",
+	"CUP_Weapons_G36",
+	"CUP_Weapons_HK416",
+	"CUP_Weapons_L129",
+	"CUP_Weapons_L85",
+	"CUP_Weapons_M1014",
+	"CUP_Weapons_M107",
+	"CUP_Weapons_M110",
+	"CUP_Weapons_M14",
+	"CUP_Weapons_M14_DMR",
+	"CUP_Weapons_M16",
+	"CUP_Weapons_M24",
+	"CUP_Weapons_M240",
+	"CUP_Weapons_M249",
+	"CUP_Weapons_M60E4",
+	"CUP_Weapons_Mk48",
+	"CUP_Weapons_RSASS",
+	"CUP_Weapons_Sa58",
+	"CUP_Weapons_SCAR",
+	"CUP_Weapons_Steyr",
+	"CUP_Weapons_West_Attachments",
+	"CUP_Weapons_XM8"];
+a3e_additional_weapon_box_arsenal_weapons = [
+	"CUP_glaunch_M32",
+	"CUP_glaunch_M79",
+	"CUP_glaunch_Mk13"];
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite

--- a/Mods/CUP-BAF w/UnitClasses.sqf
+++ b/Mods/CUP-BAF w/UnitClasses.sqf
@@ -895,6 +895,39 @@ a3e_arr_AquaticPatrols = [
 //////////////////////////////////////////////////////////////////
 a3e_additional_weapon_box_1 = "CUP_USBasicWeaponsBox";
 a3e_additional_weapon_box_2 = "CUP_USSpecialWeaponsBox";
+a3e_additional_weapon_box_arsenal_cfgPatches = [
+	"CUP_Weapons_AA12",
+	"CUP_Weapons_ACR",
+	"CUP_Weapons_AS50",
+	"CUP_Weapons_AWM",
+	"CUP_Weapons_CZ750",
+	"CUP_Weapons_CZ805",
+	"CUP_Weapons_EVO",
+	"CUP_Weapons_G36",
+	"CUP_Weapons_HK416",
+	"CUP_Weapons_L129",
+	"CUP_Weapons_L85",
+	"CUP_Weapons_M1014",
+	"CUP_Weapons_M107",
+	"CUP_Weapons_M110",
+	"CUP_Weapons_M14",
+	"CUP_Weapons_M14_DMR",
+	"CUP_Weapons_M16",
+	"CUP_Weapons_M24",
+	"CUP_Weapons_M240",
+	"CUP_Weapons_M249",
+	"CUP_Weapons_M60E4",
+	"CUP_Weapons_Mk48",
+	"CUP_Weapons_RSASS",
+	"CUP_Weapons_Sa58",
+	"CUP_Weapons_SCAR",
+	"CUP_Weapons_Steyr",
+	"CUP_Weapons_West_Attachments",
+	"CUP_Weapons_XM8"];
+a3e_additional_weapon_box_arsenal_weapons = [
+	"CUP_glaunch_M32",
+	"CUP_glaunch_M79",
+	"CUP_glaunch_Mk13"];
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite

--- a/Mods/CUP-US Army d/UnitClasses.sqf
+++ b/Mods/CUP-US Army d/UnitClasses.sqf
@@ -885,6 +885,39 @@ a3e_arr_AquaticPatrols = [
 //////////////////////////////////////////////////////////////////
 a3e_additional_weapon_box_1 = "CUP_USBasicWeaponsBox";
 a3e_additional_weapon_box_2 = "CUP_USSpecialWeaponsBox";
+a3e_additional_weapon_box_arsenal_cfgPatches = [
+	"CUP_Weapons_AA12",
+	"CUP_Weapons_ACR",
+	"CUP_Weapons_AS50",
+	"CUP_Weapons_AWM",
+	"CUP_Weapons_CZ750",
+	"CUP_Weapons_CZ805",
+	"CUP_Weapons_EVO",
+	"CUP_Weapons_G36",
+	"CUP_Weapons_HK416",
+	"CUP_Weapons_L129",
+	"CUP_Weapons_L85",
+	"CUP_Weapons_M1014",
+	"CUP_Weapons_M107",
+	"CUP_Weapons_M110",
+	"CUP_Weapons_M14",
+	"CUP_Weapons_M14_DMR",
+	"CUP_Weapons_M16",
+	"CUP_Weapons_M24",
+	"CUP_Weapons_M240",
+	"CUP_Weapons_M249",
+	"CUP_Weapons_M60E4",
+	"CUP_Weapons_Mk48",
+	"CUP_Weapons_RSASS",
+	"CUP_Weapons_Sa58",
+	"CUP_Weapons_SCAR",
+	"CUP_Weapons_Steyr",
+	"CUP_Weapons_West_Attachments",
+	"CUP_Weapons_XM8"];
+a3e_additional_weapon_box_arsenal_weapons = [
+	"CUP_glaunch_M32",
+	"CUP_glaunch_M79",
+	"CUP_glaunch_Mk13"];
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite

--- a/Mods/CUP-US USMC/UnitClasses.sqf
+++ b/Mods/CUP-US USMC/UnitClasses.sqf
@@ -788,6 +788,39 @@ a3e_arr_AquaticPatrols = [
 //////////////////////////////////////////////////////////////////
 a3e_additional_weapon_box_1 = "CUP_USBasicWeaponsBox";
 a3e_additional_weapon_box_2 = "CUP_USSpecialWeaponsBox";
+a3e_additional_weapon_box_arsenal_cfgPatches = [
+	"CUP_Weapons_AA12",
+	"CUP_Weapons_ACR",
+	"CUP_Weapons_AS50",
+	"CUP_Weapons_AWM",
+	"CUP_Weapons_CZ750",
+	"CUP_Weapons_CZ805",
+	"CUP_Weapons_EVO",
+	"CUP_Weapons_G36",
+	"CUP_Weapons_HK416",
+	"CUP_Weapons_L129",
+	"CUP_Weapons_L85",
+	"CUP_Weapons_M1014",
+	"CUP_Weapons_M107",
+	"CUP_Weapons_M110",
+	"CUP_Weapons_M14",
+	"CUP_Weapons_M14_DMR",
+	"CUP_Weapons_M16",
+	"CUP_Weapons_M24",
+	"CUP_Weapons_M240",
+	"CUP_Weapons_M249",
+	"CUP_Weapons_M60E4",
+	"CUP_Weapons_Mk48",
+	"CUP_Weapons_RSASS",
+	"CUP_Weapons_Sa58",
+	"CUP_Weapons_SCAR",
+	"CUP_Weapons_Steyr",
+	"CUP_Weapons_West_Attachments",
+	"CUP_Weapons_XM8"];
+a3e_additional_weapon_box_arsenal_weapons = [
+	"CUP_glaunch_M32",
+	"CUP_glaunch_M79",
+	"CUP_glaunch_Mk13"];
 
 //////////////////////////////////////////////////////////////////
 // fn_MortarSite


### PR DESCRIPTION
When merged this pull request will:
- title;
- add lists to CUP RU and US/BAF configs.

Additional weapon boxes on ammo points contain all weapons from appropriate side. We can add arsenal to these boxes with configured weapons/mags from this side.

Weapons are generated both from cfgPatches and weapons lists. cfgPatches allow to simplify lists very much. At least vanilla, CUP and RHS weapons are grouped to per-side configs and can be used this way.

Lists are not mandatory to present in UnitClasses. If there isn't lists in config, arsenal won't be added.