### PR TITLE
changing motorpool spawns/ammo/fuel/damage

### DIFF
--- a/Code/functions/Server/fn_createMotorPool.sqf
+++ b/Code/functions/Server/fn_createMotorPool.sqf
@@ -70,7 +70,7 @@ private _playergroup = [] call A3E_fnc_getPlayerGroup;
 {
     // Fixme: hard coding to 180° orientation for now
     [_x, 180, a3e_arr_ComCenStaticWeapons,
-     a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses, 
+     a3e_arr_ComCenParkedVehicles, 
      a3e_arr_ComCenDefence_lightArmorClasses + a3e_arr_ComCenDefence_heavyArmorClasses]
      call A3E_fnc_BuildMotorPool;
 

--- a/Code/functions/Templates/fn_BuildMotorPool.sqf
+++ b/Code/functions/Templates/fn_BuildMotorPool.sqf
@@ -581,13 +581,10 @@ if (count _parkedArmorClasses > 0) then {
     _dir = 180;
     
     _sarmor = [_armor, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateVehicle;
-	_sarmor setdamage (random [0, 0.2, 0.5]);
 	
-    if (["ammo", "fuel"] call BIS_fnc_selectRandom == "ammo") then {
-        _sarmor setFuel 0.01;
-    } else {
-        _sarmor setFuel 0.01;
-    };
+	_sarmor setfuel random [0.05, 0.10, 0.15];
+	_sarmor setdamage random [0.25, 0.5, 0.9];
+	_sarmor setVehicleAmmo random [0, 0.5, 1];
 
 };
 // setVehicleAmmo cannot be used until Ammo Depots rearm all vehicles
@@ -602,29 +599,33 @@ if (count _parkedVehicleClasses > 0) then {
     _vehicle = selectRandom _parkedVehicleClasses;
     _stupidvehicle = [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateVehicle;
 	
-	_stupidvehicle setfuel (random 1);
-	_stupidvehicle setdamage (random [0, 0.2, 0.5]);
+	_stupidvehicle setfuel random 1;
+	_stupidvehicle setdamage random [0, 0.2, 0.5];
+	_stupidvehicle setVehicleAmmo random [0, 0.5, 1];
 };
 
 _random = random 1;
-if (_random < .3 ) then {
+if (_random > .5 ) then {
     _pos = [-20.35, -1.202];
     _dir = 100;
     
     _vehicle = selectRandom _parkedVehicleClasses;
     _stupidvehicle = [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	
-	_stupidvehicle setfuel (random 1);
-	_stupidvehicle setdamage (random [0, 0.2, 0.5]);
+	_stupidvehicle setfuel random 1;
+	_stupidvehicle setdamage random [0, 0.2, 0.5];
+	_stupidvehicle setVehicleAmmo random [0, 0.5, 1];
 };
-if (_random > .9) then {
+if (_random > .75) then {
     _pos = [-15.247, 12.6];
     _dir = 144;
    
-    _stupidvehicle = ["B_G_Offroad_01_armed_F", _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
+     _vehicle = selectRandom _parkedVehicleClasses;
+    _stupidvehicle = [_vehicle, _pos, _dir, _centerPos, _rotateDir] call _fnc_CreateObject;
 	
 	_stupidvehicle setfuel random 1;
 	_stupidvehicle setdamage random [0, 0.2, 0.5];
+	_stupidvehicle setVehicleAmmo random [0, 0.5, 1];
 };
 
 ["A3E_MotorPoolMapMarker" + str _mNumber,_centerPos,"o_service"] call A3E_fnc_createLocationMarker;


### PR DESCRIPTION
I've been using these values on my server for a while and I think they greatly improve the gameplay and functionality of the Motorpool.

I changed the heavy vehicle to spawn with more fuel since 1% for some vehicles is barely enough to move a couple hundred meters.  To compensate for this I adjusted the damage values to start at a higher value and can go up to a much higher value.

I changed the second vehicle from always being a civilian vehicle to being one from the `a3e_arr_ComCenParkedVehicles` array.  It never made much sense why a civilian vehicle is in the motorpool and this feels much more immersive and is more useful for the players without being too overpowered.

I also increased the chance of the the other two vehicles spawning and I changed the one that always spawns as a `B_G_Offroad_01_armed_F` to another one from `a3e_arr_ComCenParkedVehicles`.

I also changed all vehicles to have random ammo values so players might want to stop at an ammobase to rearm.