### PR TITLE
workaround for Ruha Thermal Imaging Bug

### DIFF
--- a/Missions/Ruha/mission.sqm
+++ b/Missions/Ruha/mission.sqm
@@ -99,9 +99,9 @@ class Mission
 		forecastWind=0.099999994;
 		forecastWaves=0.099999994;
 		forecastLightnings=0.099999994;
-		year=2008;
-		month=6;
-		day=24;
+		year=2019;
+		month=8;
+		day=27;
 		hour=15;
 		startFogDecay=0.013;
 		forecastFogDecay=0.013;


### PR DESCRIPTION
Seems like when month is set to Jan/Feb/Mar/Dec thermal imaging completely breaks on this map. Changing it to any other month fixes it. I still kept the full moon night.

I checked Anizay and Summa and they didn't seem to have the same issue.

Here's some screenshots demonstrating the issue: https://imgur.com/a/G7JBkWQ