### PR TITLE
CUP Magazine Classname Change

### DIFF
--- a/Mods/CUP Desert GER vs Taki Army-Taki GUE/UnitClasses.sqf
+++ b/Mods/CUP Desert GER vs Taki Army-Taki GUE/UnitClasses.sqf
@@ -1554,8 +1554,8 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 1
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 0];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_SA61","CUP_20Rnd_B_765x17_Ball_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];

--- a/Mods/CUP Sahrani USMC vs SLA-RACS/UnitClasses.sqf
+++ b/Mods/CUP Sahrani USMC vs SLA-RACS/UnitClasses.sqf
@@ -861,7 +861,7 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL5061_wooden", "CUP_20Rnd_7
 a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A1_ZDDot_Laser", "CUP_30Rnd_556x45_Stanag", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_M240", "CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M", 5];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 8];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ750_SOS_bipod", "CUP_10Rnd_762x51_CZ750", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_slamfire", "CUP_1Rnd_12Gauge_Pellets_No00_Buck", 20];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_slamfire", "CUP_1Rnd_12Gauge_HE", 20];

--- a/Mods/CUP Tropical SLA vs HIL-RACS/Unitclasses.sqf
+++ b/Mods/CUP Tropical SLA vs HIL-RACS/Unitclasses.sqf
@@ -1533,7 +1533,7 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_PB6P9_snds", "CUP_8Rnd_9x18_Makar
 a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL_railed", "CUP_20Rnd_762x51_FNFAL_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Pellets", 4];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_74Slug", 4];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_M14", "CUP_20Rnd_762x51_DMR", 8];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_MicroUzi_snds", "CUP_30Rnd_9x19_UZI", 4];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_UK59", "CUP_50Rnd_UK59_762x54R_Tracer", 6];

--- a/Mods/CUP Winter RU vs CDF-ION PMC/UnitClasses.sqf
+++ b/Mods/CUP Winter RU vs CDF-ION PMC/UnitClasses.sqf
@@ -886,7 +886,7 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_LeeEnfield", "CUP_10x_303_M", 1
 a3e_arr_CivilianCarWeapons pushback ["CUP_launch_RPG18","CUP_RPG18_M", 1];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_SA61","CUP_20Rnd_B_765x17_Ball_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_SA61","CUP_50Rnd_B_765x17_Ball_M", 3];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["MineDetector", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Medikit", objNull, 0];
 //a3e_arr_CivilianCarWeapons pushback ["Toolkit", objNull, 0];

--- a/Mods/CUP Winter UA vs RU-ChDKZ/UnitClasses.sqf
+++ b/Mods/CUP Winter UA vs RU-ChDKZ/UnitClasses.sqf
@@ -655,7 +655,7 @@ a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_smg_BallisticShield_PP19", 30, 2,
 a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_arifle_OTS14_GROZA_762_GL", 30, 2, 4, ["CUP_30Rnd_762x39_AK47_M","CUP_1Rnd_HE_GP25_M"], 6];
 // non-CAST weapons
 a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_arifle_Sa58_Klec", 20, 2, 4, ["CUP_45Rnd_Sa58_M"], 6];
-a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_CZ550", 40, 1, 2, ["CUP_5x_22_LR_17_HMR_M"], 6];
+a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_srifle_CZ550", 40, 1, 2, ["CUP_5Rnd_93x64_CZ550"], 6];
 a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_PKM", 30, 1, 2, ["CUP_100Rnd_TE4_LRT4_762x54_PK_Tracer_Green_M"], 6];
 a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_lmg_UK59", 10, 1, 2, ["CUP_50Rnd_UK59_762x54R_Tracer"], 6];
 a3e_arr_AmmoDepotSpecialWeapons pushback ["CUP_smg_bizon_snds", 50, 1, 2, ["CUP_64Rnd_9x19_Bizon_M"], 7];
@@ -771,7 +771,7 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A1_ZDDot_Laser", "CUP_30R
 a3e_arr_CivilianCarWeapons pushback ["CUP_CZ_BREN2_556_14_Grn", "CUP_30Rnd_556x45_Stanag", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_M240", "CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M", 5];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_Mosin_Nagant", "CUP_5Rnd_762x54_Mosin_M", 8];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ750_SOS_bipod", "CUP_10Rnd_762x51_CZ750", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_slamfire", "CUP_1Rnd_12Gauge_Pellets_No00_Buck", 20];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_slamfire", "CUP_1Rnd_12Gauge_HE", 20];

--- a/Mods/CUP Woodland RU vs USMC-RACS/UnitClasses.sqf
+++ b/Mods/CUP Woodland RU vs USMC-RACS/UnitClasses.sqf
@@ -1209,7 +1209,7 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_PB6P9_snds", "CUP_8Rnd_9x18_Makar
 a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_FNFAL_railed", "CUP_20Rnd_762x51_FNFAL_M", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_Pellets", 11];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_AA12", "CUP_20Rnd_B_AA12_74Slug", 9];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_M14", "CUP_20Rnd_762x51_DMR", 8];
 a3e_arr_CivilianCarWeapons pushback ["CUP_hgun_MicroUzi_snds", "CUP_30Rnd_9x19_UZI", 4];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_UK59", "CUP_50Rnd_UK59_762x54R_Tracer", 6];

--- a/Mods/CUP Woodland USMC vs RU-NAPA/UnitClasses.sqf
+++ b/Mods/CUP Woodland USMC vs RU-NAPA/UnitClasses.sqf
@@ -736,7 +736,7 @@ a3e_arr_CivilianCarWeapons pushback ["CUP_arifle_CZ805_A1_ZDDot_Laser", "CUP_30R
 a3e_arr_CivilianCarWeapons pushback ["CUP_CZ_BREN2_556_14_Grn", "CUP_30Rnd_556x45_Stanag", 7];
 a3e_arr_CivilianCarWeapons pushback ["CUP_lmg_M240", "CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M", 5];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_Mosin_Nagant", "CUP_5Rnd_762x54_Mosin_M", 8];
-a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10];
+a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_srifle_CZ750_SOS_bipod", "CUP_10Rnd_762x51_CZ750", 10];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_slamfire", "CUP_1Rnd_12Gauge_Pellets_No00_Buck", 20];
 a3e_arr_CivilianCarWeapons pushback ["CUP_sgun_slamfire", "CUP_1Rnd_12Gauge_HE", 20];

--- a/Mods/Civ/Civ_CUP.sqf
+++ b/Mods/Civ/Civ_CUP.sqf
@@ -62,5 +62,5 @@ a3e_arr_Escape_EnemyCivilianCarTypes append [
 // Index 2: Number of magazines.
 a3e_arr_CivilianCarWeapons append [
 	["CUP_arifle_AKS_Gold", "CUP_30Rnd_545x39_AK_M", 5]
-	,["CUP_srifle_CZ550", "CUP_5x_22_LR_17_HMR_M", 10]
+	,["CUP_srifle_CZ550", "CUP_5Rnd_93x64_CZ550", 10]
 	];


### PR DESCRIPTION
CUP Units Update
Version 1.19.0 (31|Dec|2025)
Deprecate CZ 550 magazine `CUP_5x_22_LR_17_HMR_M` in favour of `CUP_5Rnd_93x64_CZ550`